### PR TITLE
Patch 1

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -20,7 +20,7 @@ system administrator.
 Installation
 ------------
 
-To install Singularity please follow the instructions on our readthedoc pages here :ref:`install Singularity <installation>` 
+To install Singularity please follow the instructions on our github here https://github.com/singularityware/singularity/blob/master/INSTALL.md
 
 -------------------------------------
 Overview of the Singularity Interface

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -20,23 +20,7 @@ system administrator.
 Installation
 ------------
 
-There are many ways to :ref:`install Singularity <installation>` but this quick start guide will only cover one.
-
-.. code-block:: none
-
-    git clone https://github.com/singularityware/singularity.git
-
-    cd singularity
-
-    ./autogen.sh
-
-    ./configure --prefix=/usr/local
-
-    make
-
-    sudo make install
-
-Singularity must be installed as root to function properly.
+To install Singularity please follow the instructions on our readthedoc pages here :ref:`install Singularity <installation>` 
 
 -------------------------------------
 Overview of the Singularity Interface


### PR DESCRIPTION
The previous installation instructions did not correspond to the current singularity repository.
For example, there is no autogen.sh file.  

I propose to only keep the link to the up to date tuto on github