### PR TITLE
Updating defaults.py url

### DIFF
--- a/build_environment.rst
+++ b/build_environment.rst
@@ -87,7 +87,7 @@ Environment Variables
 ---------------------
 
 All environmental variables are parsed by Singularity python helper
-functions, and specifically the file `defaults.py <https://github.com/singularityware/singularity/blob/master/libexec/python/defaults.py>`_ is a gateway
+functions, and specifically the file `defaults.py <https://github.com/singularityware/singularity/blob/2.6.0/libexec/python/defaults.py>`_ is a gateway
 between variables defined at runtime, and pre-defined defaults. By way
 of import from the file, variables set at runtime do not change if
 re-imported. This was done intentionally to prevent changes during the


### PR DESCRIPTION
This fixes issue #5 : `defaults.py` is not present anymore in latest version of Singularity, up to v2.6.0 the location should be https://github.com/singularityware/singularity/blob/2.6.0/libexec/python/defaults.py