### PR TITLE
Changed branch to use from 2.6 to release-2.6 Fixes #14

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -30,7 +30,7 @@ You will need ``git`` to download the source code and the appropriate tools and 
 
     git fetch --all
 
-    git checkout 2.6.0
+    git checkout release-2.6
 
     ./autogen.sh
 


### PR DESCRIPTION
Fix instruction in https://www.sylabs.io/guides/2.6/user-guide/quick_start.html
Changed branch to use from 26 to release-2.6