### PR TITLE
bind_paths_and_mounts: formatting error

### DIFF
--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -40,7 +40,7 @@ User-defined bind paths
 If the system administrator has `enabled user control of binds <https://singularity-admindoc.readthedocs.io/en/latest/the_singularity_config_file.html#user-bind-control-boolean-default-yes>`_,
 you will be able to request your own bind paths within your container.
 
-The Singularity action commands (``run``, ``exec`` ,``shell``, and
+The Singularity action commands (``run``, ``exec``, ``shell``, and
 ``instance start`` will accept the ``--bind/-B`` command-line option to specify
 bind paths, and will also honor the ``$SINGULARITY_BIND`` (or
 ``$SINGULARITY_BINDPATH``) environment variable. The argument for this option is


### PR DESCRIPTION
This is a pretty simple change to fix the monospace formatting. I was actually looking through the site looking for a place to add documentation about converting local docker images, but it seems that not everything from the old site has been migrated over to here yet, like http://singularity.lbl.gov/docs-recipes.