### PR TITLE
add Pygments lexer for Singularity definition files

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -26,14 +26,14 @@ containers from that existing base container adding customizations in ``%post``,
 Keywords
 ========
 
-.. code-block:: none
+.. code-block:: singularity
 
     Bootstrap: library
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap module to
 use.
 
-.. code-block:: none
+.. code-block:: singularity
 
     From: <entity>/<collection>/<container>:<tag>
 
@@ -43,7 +43,7 @@ optional and defaults to ``default``. This is the correct namespace to use for
 some official containers (``alpine`` for example). ``tag`` is also optional and
 will default to ``latest``.
 
-.. code-block:: none
+.. code-block:: singularity
 
     Library: http://custom/library
 
@@ -80,14 +80,14 @@ containers. If so, you can seamlessly convert them to Singularity with the
 Keywords
 ========
 
-.. code-block:: none
+.. code-block:: singularity
 
     Bootstrap: docker
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap module to
 use.
 
-.. code-block:: none
+.. code-block:: singularity
 
     From: <registry>/<namespace>/<container>:<tag>@<digest>
 
@@ -100,19 +100,19 @@ default to ``latest``
 See :ref:`Singularity and Docker <singularity-and-docker>` for more detailed
 info on using Docker registries.
 
-.. code-block:: none
+.. code-block:: singularity
 
     Registry: http://custom_registry
 
 The Registry keyword is optional. It will default to ``index.docker.io``.
 
-.. code-block:: none
+.. code-block:: singularity
 
     Namespace: namespace
 
 The Namespace keyword is optional. It will default to ``library``.
 
-.. code-block:: none
+.. code-block:: singularity
 
     IncludeCmd: yes
 
@@ -165,14 +165,14 @@ from that existing base container adding customizations in ``%post`` ,
 Keywords
 ========
 
-.. code-block:: none
+.. code-block:: singularity
 
     Bootstrap: shub
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap module to
 use.
 
-.. code-block:: none
+.. code-block:: singularity
 
     From: shub://<registry>/<username>/<container-name>:<tag>@digest
 
@@ -216,14 +216,14 @@ container in ``%post``, ``%environment``, ``%runscript``, etc.
 Keywords
 ========
 
-.. code-block:: none
+.. code-block:: singularity
 
     Bootstrap: localimage
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap module to
 use.
 
-.. code-block:: none
+.. code-block:: singularity
 
     From: /path/to/container/file/or/directory
 
@@ -259,14 +259,14 @@ also specify the URI for the mirror you would like to use.
 Keywords
 ========
 
-.. code-block:: none
+.. code-block:: singularity
 
     Bootstrap: yum
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap module to
 use.
 
-.. code-block:: none
+.. code-block:: singularity
 
     OSVersion: 7
 
@@ -274,7 +274,7 @@ The OSVersion keyword is optional. It specifies the OS version you would like to
 use. It is only required if you have specified a %{OSVERSION} variable in the
 ``MirrorURL`` keyword.
 
-.. code-block:: none
+.. code-block:: singularity
 
     MirrorURL: http://mirror.centos.org/centos-%{OSVERSION}/%{OSVERSION}/os/$basearch/
 
@@ -282,7 +282,7 @@ The MirrorURL keyword is mandatory. It specifies the URI to use as a mirror to
 download the OS. If you define the ``OSVersion`` keyword, than you can use it in
 the URI as in the example above.
 
-.. code-block:: none
+.. code-block:: singularity
 
     Include: yum
 
@@ -334,14 +334,14 @@ use.
 Keywords
 ========
 
-.. code-block:: none
+.. code-block:: singularity
 
     Bootstrap: debootstrap
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap module to
 use.
 
-.. code-block:: none
+.. code-block:: singularity
 
     OSVersion: xenial
 
@@ -351,14 +351,14 @@ to use. For Ubuntu you can use code words like ``trusty`` (14.04), ``xenial``
 ``oldstable``, ``testing``, and ``unstable`` or code words like ``wheezy`` (7),
 ``jesse`` (8), and ``stretch`` (9).
 
- .. code-block:: none
+ .. code-block:: singularity
 
      MirrorURL:  http://us.archive.ubuntu.com/ubuntu/
 
 The MirrorURL keyword is mandatory. It specifies a URI to use as a mirror when
 downloading the OS.
 
-.. code-block:: none
+.. code-block:: singularity
 
     Include: somepackage
 
@@ -403,7 +403,7 @@ Arch Linux uses the aptly named ``pacman`` package manager (all puns intended).
 Keywords
 ========
 
-.. code-block:: none
+.. code-block:: singularity
 
     Bootstrap: arch
 
@@ -445,14 +445,14 @@ also specify a URI for the mirror you would like to use.
 Keywords
 ========
 
-.. code-block:: none
+.. code-block:: singularity
 
     Bootstrap: busybox
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap module to
 use.
 
-.. code-block:: none
+.. code-block:: singularity
 
     MirrorURL: https://www.busybox.net/downloads/binaries/1.26.1-defconfig-multiarch/busybox-x86_64
 
@@ -484,14 +484,14 @@ also specify a URI for the mirror you would like to use.
 Keywords
 ========
 
-.. code-block:: none
+.. code-block:: singularity
 
     Bootstrap: zypper
 
 The Bootstrap keyword is always mandatory. It describes the bootstrap module to
 use.
 
-.. code-block:: none
+.. code-block:: singularity
 
     OSVersion: 42.2
 
@@ -499,7 +499,7 @@ The OSVersion keyword is optional. It specifies the OS version you would like to
 use. It is only required if you have specified a %{OSVERSION} variable in the
 ``MirrorURL`` keyword.
 
-.. code-block:: none
+.. code-block:: singularity
 
     Include: somepackage
 

--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -128,11 +128,11 @@ Building containers from Singularity definition files
 
 Of course, Singularity definition files can be used as the target when building
 a container. For detailed information on writing Singularity definition files,
-please see the :ref:`Container Definition docs <container-recipes>`. Let’s say
+please see the :doc:`Container Definition docs <definition_files>`. Let’s say
 you already have the following container definition file called ``lolcow.def``,
 and you want to use it to build a SIF container.
 
-.. code-block:: none
+.. code-block:: singularity
 
     Bootstrap: docker
     From: ubuntu:16.04

--- a/conf.py
+++ b/conf.py
@@ -273,3 +273,13 @@ texinfo_documents = [
 
 # If true, do not generate a @detailmenu in the "Top" node's menu.
 #texinfo_no_detailmenu = False
+
+
+# -- Custom lexer ---------------------------------------------------------
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '.'))
+from sphinx.highlighting import lexers
+from pygments_singularity import SingularityLexer
+
+# lexer for Singularity definition files (added here until it is upstreamed into Pygments).
+lexers['singularity'] = SingularityLexer(startinline=True)

--- a/definition_files.rst
+++ b/definition_files.rst
@@ -59,7 +59,7 @@ valid in the header. For example, when using the ``library`` bootstrap agent,
 the ``From`` keyword becomes valid. Observe the following example for building a
 Debian container from the Container Library:
 
-.. code-block:: none
+.. code-block:: singularity
 
     Bootstrap: library
     From: debian:7
@@ -67,7 +67,7 @@ Debian container from the Container Library:
 A def file that uses an official mirror to install Centos-7 might look like
 this:
 
-.. code-block:: none
+.. code-block:: singularity
 
     Bootstrap: yum
     OSVersion: 7
@@ -109,7 +109,7 @@ any sections at all) within a def file. Furthermore, the order of the sections
 in the def file is unimportant and multiple sections of the same name can be
 included and will be appended to one another during the build process.
 
-.. code-block:: none
+.. code-block:: singularity
 
     Bootstrap: library
     From: ubuntu:18.04
@@ -172,7 +172,7 @@ the ``%setup`` section.
 
 Consider the example from the definition file above:
 
-.. code-block:: none
+.. code-block:: singularity
 
     %setup
         touch /file1
@@ -201,7 +201,7 @@ specification can be omitted and will be assumed to be the same path as the
 
 Consider the example from the definition file above:
 
-.. code-block:: none
+.. code-block:: singularity
 
     %files
         /file1
@@ -232,7 +232,7 @@ them in your ``%post`` section. Specifically:
 You should use the same conventions that you would use in a ``.bashrc`` or
 ``.profile`` file. Consider this example from the def file above:
 
-.. code-block:: none
+.. code-block:: singularity
 
     %environment
         export LISTEN_PORT=12345
@@ -276,7 +276,7 @@ libraries, write configuration files, create new directories, etc.
 
 Consider the example from the definition file above:
 
-.. code-block:: none
+.. code-block:: singularity
 
     %post
         apt-get update && apt-get install -y netcat
@@ -313,7 +313,7 @@ arguments within your runscript.
 
 Consider the example from the def file above:
 
-.. code-block:: none
+.. code-block:: singularity
 
     %runscript
         echo "Container was created $NOW"
@@ -353,7 +353,7 @@ executed when the ``instance start`` command is issued.
 
 Consider the example from the def file above.
 
-.. code-block:: none
+.. code-block:: singularity
 
     %startscript
         nc -lp $LISTEN_PORT
@@ -382,7 +382,7 @@ through the container itself, using the ``test`` command.
 
 Consider the example from the def file above:
 
-.. code-block:: none
+.. code-block:: singularity
 
     %test
         grep -q NAME=\"Ubuntu\" /etc/os-release
@@ -422,7 +422,7 @@ name-value pair.
 
 Consider the example from the def file above:
 
-.. code-block:: none
+.. code-block:: singularity
 
     %labels
         Author d@sylabs.io
@@ -458,7 +458,7 @@ container during the build. This text can then be displayed using the
 
 Consider the example from the def file above:
 
-.. code-block:: none
+.. code-block:: singularity
 
     %help
         This is a demo container used to illustrate a def file that uses all
@@ -484,7 +484,7 @@ Integration Format (SCI-F) <https://sci-f.github.io/>`_
 The following runscript demonstrates how to build 2 different apps into the
 same container using SCI-F modules:
 
-.. code-block:: none
+.. code-block:: singularity
 
     Bootstrap: docker
     From: ubuntu

--- a/pygments_singularity.py
+++ b/pygments_singularity.py
@@ -1,0 +1,34 @@
+from pygments.lexer import RegexLexer, bygroups, using, words
+from pygments.token import *
+from pygments.lexers.shell import BashLexer
+import re
+
+class SingularityLexer(RegexLexer):
+    """
+    Lexer for `Singularity definition files
+    <https://www.sylabs.io/guides/3.0/user-guide/definition_files.html>`_.
+    """
+
+    name = 'Singularity'
+    aliases = ['singularity']
+    filenames = ['*.def', 'Singularity']
+    flags = re.IGNORECASE | re.MULTILINE | re.DOTALL
+
+    _headers = r'^(\s)*(bootstrap|from|osversion|mirrorurl|include)(:)'
+    _section = r'^%(?:post|setup|environment|help|labels|test|runscript|files|startscript)\b'
+    _appsect = r'^%app(?:install|help|run|labels|env|test|files)\b'
+
+    tokens = {
+        'root': [
+            (_section, Generic.Heading, 'script'),
+            (_appsect, Generic.Heading, 'script'),
+            (_headers, bygroups(Text, Keyword, Text)),
+            (r'\s*#.*?\n', Comment),
+            (r'\b(([0-9]+\.?[0-9]*)|(\.[0-9]+))\b', Number),
+            (r'(?!^\s*%).', Text),
+        ],
+        'script': [
+            (r'(.+?(?=^\s*%))|(.*)', using(BashLexer), '#pop'),
+        ],
+    }
+

--- a/pygments_singularity.py
+++ b/pygments_singularity.py
@@ -14,8 +14,8 @@ class SingularityLexer(RegexLexer):
     filenames = ['*.def', 'Singularity']
     flags = re.IGNORECASE | re.MULTILINE | re.DOTALL
 
-    _headers = r'^(\s)*(bootstrap|from|osversion|mirrorurl|include)(:)'
-    _section = r'^%(?:post|setup|environment|help|labels|test|runscript|files|startscript)\b'
+    _headers = r'^(\s)*(bootstrap|from|osversion|mirrorurl|include|registry|namespace|includecmd)(:)'
+    _section = r'^%(?:pre|post|setup|environment|help|labels|test|runscript|files|startscript)\b'
     _appsect = r'^%app(?:install|help|run|labels|env|test|files)\b'
 
     tokens = {

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -583,7 +583,7 @@ container from the host system.
 
 Here is an example of a definition file:
 
-.. code-block:: none
+.. code-block:: singularity
 
     BootStrap: library
     From: ubuntu:16.04


### PR DESCRIPTION
## Description of the Pull Request (PR):

These changes add a local Pygments lexer for Singularity definition files; e.g.:

![deepinscreenshot_select-area_20181230010709](https://user-images.githubusercontent.com/32495955/50544804-509b4680-0bcf-11e9-8d3a-4da1b1f59127.png)

Here's a test file (an image since GitHub doesn't allow HTML):

![deepinscreenshot_select-area_20181230010603](https://user-images.githubusercontent.com/32495955/50544799-1fbb1180-0bcf-11e9-8d15-6f0df0d3d79f.png)

I'll also be adding this into the upstream repo so feel free to close this PR if you'd rather wait for that. I'm not incredibly familiar with the definition file syntax so I'm mostly looking for feedback before attempting to add the lexer into Pygments.

## This fixes or addresses the following GitHub issues:

- None