### PR TITLE
Ignoring __pycache__ folder from git changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 
 .idea
 .DS_Store
+__pycache__
 
 !_build/html/_static/js/
 _build/doctrees/


### PR DESCRIPTION
Fixes #59 , this is also related to PR #54 

## Description of the Pull Request (PR):

`__pycache__` folder added to the git ignore file.

## This fixes or addresses the following GitHub issues:

- Fixes #59
