### PR TITLE
Updated footer ref from 3.0 to master branch on contributing link 

### DIFF
--- a/_build/html/_static/js/footer.js
+++ b/_build/html/_static/js/footer.js
@@ -18,7 +18,7 @@ document.write('<div class="rst-versions" data-toggle="rst-versions" role="note"
      <dl>\
        <dt>Do you want to contribute? </dt>\
          <dd>\
-           <a href="https://github.com/sylabs/singularity-userdocs/tree/3.0">Find us on GitHub!</a>\
+           <a href="https://github.com/sylabs/singularity-userdocs/tree/master">Find us on GitHub!</a>\
          </dd>\
      </dl>\
 \


### PR DESCRIPTION
Fixes: #61 

## Description of the Pull Request (PR):
![image](https://user-images.githubusercontent.com/2277700/50882443-1ad33a80-13e5-11e9-8232-61e31945c309.png)

Considering master branch on footer for contributing instead of 3.0 branch. (Refers to the link "Find us on GitHub!")

## This fixes or addresses the following GitHub issues:

- Fixes #61
