### PR TITLE
Ignoring latex folder on build from git changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ _build/html/_templates/
 _build/html/_static/*
 
 _build/epub/*
+_build/latex/*


### PR DESCRIPTION
Fixes: #62 

## Description of the Pull Request (PR):

After building the latex files with `make latexpdf``command, the `latex` folder is git ignored.

## This fixes or addresses the following GitHub issues:

- Fixes #62
