### PR TITLE
RPM build command fix

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -232,7 +232,7 @@ of the default ``/var``) you can do the following:
 
 .. code-block:: none
 
-    rpmbuild -tb --define='_localstatedir /mnt' singularity-$VERSION.tar.gz'
+    rpmbuild -tb --define='_localstatedir /mnt' singularity-$VERSION.tar.gz
 
 .. note::
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

This PR will fix remove the extra `'` after the `rpmbuild` command.

### Before:

```
rpmbuild -tb --define='_localstatedir /mnt' singularity-$VERSION.tar.gz'
```

<br>

### After:

```
rpmbuild -tb --define='_localstatedir /mnt' singularity-$VERSION.tar.gz
```
