### PR TITLE
Update Library: default example

### DIFF
--- a/appendix.rst
+++ b/appendix.rst
@@ -48,7 +48,7 @@ will default to ``latest``.
     Library: http://custom/library
 
 The Library keyword is optional. It will default to
-``https://cloud.sylabs.io/library``.
+``https://library.sylabs.io``.
 
 
 .. _build-docker-module:


### PR DESCRIPTION
This default for the Library: keyword is misleading as using it causes an error:
```sh
$ cat 2gbimage-broken.def
Bootstrap: library
From: ukyccs/default/lcc:tf-gpu-py3
Library: https://cloud.sylabs.io/library
```

```sh
$ sudo singularity build 2gbimage-broken.sif 2gbimage-broken.def
INFO:    Starting build...
 2.06 KiB / ? [-------------------------=-----------------------------------------------------------------------------------------------------------------------------------------]  21.06% 4.13 MiB/s 0s
FATAL:   While performing build: conveyor failed to get: image format not recognized
```

but this works just fine:

```sh
$ cat 2gbimage.def
Bootstrap: library
Library: https://library.sylabs.io
From: ukyccs/default/lcc:tf-gpu-py3
```

```sh
$ sudo singularity build 2gbimage.sif 2gbimage.def
INFO:    Starting build...
 195.35 KiB / 2.64 GiB [>--------------------------------------------------------------------------------------------------------------------------------------------------]   0.01% 194.32 KiB/s 3h57m01s
```