### PR TITLE
Update to use the latest (non-deprecated) vagrant box

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -472,7 +472,7 @@ different value for the ``$VM`` variable if you like.)
 
 .. code-block:: none
 
-    $ export VM=sylabs/singularity-ubuntu-bionic64 && \
+    $ export VM=sylabs/singularity-3.0-ubuntu-bionic64 && \
         vagrant init $VM && \
         vagrant up && \
         vagrant ssh


### PR DESCRIPTION
This is a time sensitive matter b/c I see that lots of folks are downloading the deprecated one and I want to delete it since it's not really supportable. 

Fixes #81 