### PR TITLE
Add warning on compressor issue on running an image on a different host

### DIFF
--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -159,7 +159,7 @@ requires root privileges.
 
 
 .. note::
-    Beware that it is possible to build an image on a host and then not running on a different host. This depends on
+    Beware that it is possible to build an image on a host and have the image not work on a different host. This could be because of
     the default compressor supported by the host. For example, when building an image on a host in which the default compressor
     is ``xz`` and then trying to run that image on a CentOS 6 node, where the only compressor available is ``gzip``.
 

--- a/build_a_container.rst
+++ b/build_a_container.rst
@@ -157,6 +157,12 @@ You can do so with the following command.
 The command requires ``sudo`` just as installing software on your local machine
 requires root privileges.
 
+
+.. note::
+    Beware that it is possible to build an image on a host and then not running on a different host. This depends on
+    the default compressor supported by the host. For example, when building an image on a host in which the default compressor
+    is ``xz`` and then trying to run that image on a CentOS 6 node, where the only compressor available is ``gzip``.
+
 -------------
 Build options
 -------------


### PR DESCRIPTION
## Description of the Pull Request (PR):

If the default compressor on a host is not the same on another host, the run command could fail because this compressor is not supported. This is explained now on the build a container section for 3.0. 


## This fixes or addresses the following GitHub issues:

- Fixes #95 
