### PR TITLE
Update `singularity keys` to `singularity key`

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -155,27 +155,30 @@ follows:
       -s, --silent             only print errors
       -t, --tokenfile string   path to the file holding your sylabs
                                authentication token (default
-                               "/home/david/.singularity/sylabs-token")
+                               "/home/jacob/.singularity/sylabs-token")
       -v, --verbose            print additional information
 
     Available Commands:
-      build       Build a new Singularity container
-      capability  Manage Linux capabilities on containers
-      exec        Execute a command within container
+      apps        List available apps within a container
+      build       Build a Singularity image
+      cache       Manage the local cache
+      capability  Manage Linux capabilities for users and groups
+      exec        Run a command within a container
       help        Help about any command
-      inspect     Display metadata for container if available
-      instance    Manage containers running in the background
-      keys        Manage OpenPGP key stores
-      pull        Pull a container from a URI
+      inspect     Show metadata for an image
+      instance    Manage containers running as services
+      key         Manage OpenPGP keys
+      oci         Manage OCI containers
+      pull        Pull an image from a URI
       push        Push a container to a Library URI
-      run         Launch a runscript within container
-      run-help    Display help for container if available
-      search      Search the library
-      shell       Run a Bourne shell within container
-      sign        Attach cryptographic signatures to container
-      test        Run defined tests for this particular container
-      verify      Verify cryptographic signatures on container
-      version     Show application version
+      run         Run the user-defined default command within a container
+      run-help    Show the user-defined help for an image
+      search      Search a Library for images
+      shell       Run a shell within a container
+      sign        Attach a cryptographic signature to an image
+      test        Run the user-defined tests within a container
+      verify      Verify cryptographic signatures attached to an image
+      version     Show the version for Singularity
 
     Examples:
       $ singularity help <command>

--- a/signNverify.rst
+++ b/signNverify.rst
@@ -60,7 +60,7 @@ like so:.
 
 .. code-block:: none
 
-    $ singularity keys newpair
+    $ singularity key newpair
     Enter your name (e.g., John Doe) : Dave Godlove
     Enter your email address (e.g., john.doe@example.com) : d@sylabs.io
     Enter optional comment (e.g., development keys) : demo
@@ -72,7 +72,7 @@ locally.`
 
 .. code-block:: none
 
-    $ singularity keys list
+    $ singularity key list
     Public key listing (/home/david/.singularity/sypgp/pgp-public):
 
     0) U: Dave Godlove (demo) <d@sylabs.io>
@@ -93,7 +93,7 @@ using the fingerprint like so:
 
 .. code-block:: none
 
-    $ singularity keys push 135E426D67D8416DE1D6AC7FFED5BBA38EE0DC4A
+    $ singularity key push 135E426D67D8416DE1D6AC7FFED5BBA38EE0DC4A
     public key `135E426D67D8416DE1D6AC7FFED5BBA38EE0DC4A` pushed to server successfully
 
 This will allow others to verify images that you have signed.
@@ -103,7 +103,7 @@ again like so.
 
 .. code-block:: none
 
-    $ singularity keys search Godlove
+    $ singularity key search Godlove
     Search results for 'Godlove'
 
     Type bits/keyID     Date       User ID
@@ -111,7 +111,7 @@ again like so.
     pub  4096R/8EE0DC4A 2018-10-08 Dave Godlove (demo) <d@sylabs.io>
     --------------------------------------------------------------------------------
 
-    $ singularity keys pull 8EE0DC4A
+    $ singularity key pull 8EE0DC4A
     1 key(s) fetched and stored in local cache /home/david/.singularity/sypgp/pgp-public
 
 But note that this only restores the *public* key (used for verifying) to your


### PR DESCRIPTION
## Description of the Pull Request (PR):

This is a minor PR which updates the `singularity keys` command to `singularity key` which is the new standardized form. The old command still works, but it's probably best from a QA standpoint not to advertise it anymore. The `singularity help` output is also updated, which includes the fix plus a few other commands that now exist in Singularity 3.1 but were missing from the docs.

## This fixes or addresses the following GitHub issues:

- Fixes #144 
