### PR TITLE
Variable passing through code blocks and plain text

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -317,14 +317,13 @@ epub_uid = epub_title
 # A list of files that should not be packed into the epub file.
 epub_exclude_files = []
 
-
 # -- Custom lexer ---------------------------------------------------------
 
 sys.path.append(os.path.join(os.path.dirname(__file__), '.'))
 from sphinx.highlighting import lexers
 from pygments_singularity import SingularityLexer
 from pygments_json import JSONLexer
-
+from replacements import *
 # lexer for Singularity definition files (added here until it is upstreamed into Pygments).
 lexers['singularity'] = SingularityLexer(startinline=True)
 lexers['json'] = JSONLexer(startinline=True)

--- a/installation.rst
+++ b/installation.rst
@@ -117,12 +117,12 @@ After that you can just run the following commands to proceed with the installat
 
 .. code-block:: none
 
-    $ export VERSION=3.1.1 && # adjust this as necessary \
+    $ export VERSION= {InstallationVersion} && # adjust this as necessary \
         mkdir -p $GOPATH/src/github.com/sylabs && \
         cd $GOPATH/src/github.com/sylabs && \
         wget https://github.com/sylabs/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
         tar -xzf singularity-${VERSION}.tar.gz && \
-        cd singularity 
+        cd singularity
 
 ====================
 Download from source

--- a/replacements.py
+++ b/replacements.py
@@ -1,0 +1,18 @@
+
+def variableReplace(app, docname, source):
+    """
+    Takes the source on rst and replaces all the needed variables declared on variable_replacements structure
+    """
+    result = source[0]
+    for key in app.config.variable_replacements:
+        result = result.replace(key, app.config.variable_replacements[key])
+    source[0] = result
+
+#Add the needed variables to be replaced either on code or on text on the next dictionary structure.
+variable_replacements = {
+    "{InstallationVersion}" : "3.1.1"
+}
+
+def setup(app):
+   app.add_config_value('variable_replacements', {}, True)
+   app.connect('source-read', variableReplace)


### PR DESCRIPTION
## Description of the Pull Request (PR):

Enhancement to pass variables around the whole documentation, either code blocks or plain text.

How to use this thing?

To reference some variables around the project, just add the variable to the variable_replacements structure on `replacements.py` , then you can call it in your rst file with the `{variable_name}` syntax

## This fixes or addresses the following GitHub issues:

- Fixes #133 
