### PR TITLE
New key commands section

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -19,6 +19,7 @@ User Guide
    Running Services <running_services>
    Environment and Metadata <environment_and_metadata>
    OCI Runtime Support <oci_runtime>
+   Key commands <key_commands>
    Sign and Verify <signNverify>
    Security Options <security_options>
    Network Options <networking>

--- a/key_commands.rst
+++ b/key_commands.rst
@@ -1,0 +1,135 @@
+.. _key_commands:
+
+Key commands
+============
+
+.. _sec:key_commands:
+
+Singularity 3.2 introduces the abilities to import, export and remove PGP keys following the OpenPGP standard via `GnuPGP (GPG) <https://www.gnupg.org/gph/en/manual.html>`_.
+These commands only modify the local keyring and are not related to the cloud keystore.
+
+.. _key_import:
+
+------------------
+Key import command
+------------------
+
+Singularity 3.2 allows you import keys reading either from binary or armored key format and automatically detect if it is a private or public key and add it to the correspondent local keystore.
+
+To give a quick view on how it works, we will first consider the case in which a user wants to import a secret (private) key to the local keystore.
+
+First we will check what's the status of the local keystore (which keys are stored by the moment before importing a new key).
+
+.. code-block:: Singularity
+
+  $ singularity key list --secret
+
+.. note::
+
+  Remember that using ``--secret`` flag or ``-s`` flag will return the secret or private local keyring as output.
+
+The output will look as it follows:
+
+.. code-block:: Singularity
+
+    Private key listing (/home/joana/.singularity/sypgp/pgp-secret):
+
+    0) U: Johnny Cash (none) <cash@sylabs.io>
+    C: 2019-04-11 22:22:28 +0200 CEST
+    F: 47282BDC661F58FA4BEBEF47CA576CBD8EF1A2B4
+    L: 3072
+    --------
+    1) U: John Green (none) <john@sylabs.io>
+    C: 2019-04-11 13:08:45 +0200 CEST
+    F: 5720799FE7B048CF36FAB8445EE1E2BD7B6342C5
+    L: 1024
+    --------
+
+.. note::
+
+    Remember that running that same command but with sudo privilege, will give you a totally different list since it will be the correspondent keystore from user ``root``
+
+After this, you can just simply import the key you need to import just by adding the exact location to the file, let's say you own a gpg key file named ``pinkie-pie.asc`` which is a secret GPG key you want to import.
+Then you will just need to run the following command to import your key:
+
+.. code-block:: Singularity
+
+  $ singularity key import $HOME/pinkie-pie.asc
+
+.. note::
+  This location is considering your key was located on the ``$HOME`` directory. You can specify any location to the file.
+
+Since you're importing a private (secret) key, you will need to specify the passphrase related to it and then a new passphrase to be added on your local keystore.
+
+.. code-block:: Singularity
+
+    Enter your old password :
+    Enter a new password for this key :
+    Retype your passphrase :
+    Key with fingerprint 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 successfully added to the keyring
+
+After this you can see if that key was correctly added to your local keystore by running ``singularity key list -s`` command:
+
+
+.. code-block:: Singularity
+
+    Private key listing (/home/joana/.singularity/sypgp/pgp-secret):
+
+      0) U: Johnny Cash (none) <cash@sylabs.io>
+      C: 2019-04-11 22:22:28 +0200 CEST
+      F: 47282BDC661F58FA4BEBEF47CA576CBD8EF1A2B4
+      L: 3072
+      --------
+      1) U: John Green (none) <john@sylabs.io>
+      C: 2019-04-11 13:08:45 +0200 CEST
+      F: 5720799FE7B048CF36FAB8445EE1E2BD7B6342C5
+      L: 1024
+      --------
+      3) U: Pinkie Pie (Eternal chaos comes with chocolate rain!) <balloons@sylabs.io>
+      C: 2019-04-26 12:07:07 +0200 CEST
+      F: 8C10B902F438E4D504C3ACF689FCFFAED5F34A77
+      L: 1024
+      --------
+
+You will see the imported key at the bottom of the list. Remember you can also import an ``ascii`` armored key and this will be automatically detected by the ``key import`` command (no need to specify the format).
+
+.. note::
+
+  In case you would like to import a public key the process remains the same, as the import command will automatically detect whether this key to be imported is either public or private.
+
+.. _key_export:
+
+------------------
+Key export command
+------------------
+
+The key export command allows you to export a key that is on your local keystore. This key could be either private or public, and the key can be exported on ``ASCII`` armored format or on binary format.
+Of course to identify the keystore and the format the syntax varies from the ``key import`` command.
+
+For example to export a public key in binary format you can run:
+
+.. code-block:: Singularity
+
+    $ singularity key export 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
+
+This will export a public binary key named ``mykey.asc`` and will save it under the home folder. If you would like to export the same public key but in an ``ASCII`` armored format, you would need to run the following command:
+
+.. code-block:: Singularity
+
+    $ singularity key export --armor 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
+
+And in the case in which you may need to export a secret key on ``ASCII`` armored format, you would need to specify from where to find the key, since the fingerprint is the same.
+
+.. code-block:: Singularity
+
+    $ singularity key export --armor --secret 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
+
+and on binary format instead:
+
+.. code-block:: Singularity
+
+    $ singularity key export --secret 8C10B902F438E4D504C3ACF689FCFFAED5F34A77 $HOME/mykey.asc
+
+.. note::
+
+    Exporting keys will not change the status of your local keystore or keyring. This will just obtain the content of the keys and save it on a local file on your host.

--- a/key_commands.rst
+++ b/key_commands.rst
@@ -49,7 +49,7 @@ The output will look as it follows:
 
     Remember that running that same command but with sudo privilege, will give you a totally different list since it will be the correspondent keystore from user ``root``
 
-After this, you can just simply import the key you need to import just by adding the exact location to the file, let's say you own a gpg key file named ``pinkie-pie.asc`` which is a secret GPG key you want to import.
+After this, you can simply import the key you need by adding the exact location to the file, let's say you own a gpg key file named ``pinkie-pie.asc`` which is a secret GPG key you want to import.
 Then you will just need to run the following command to import your key:
 
 .. code-block:: Singularity
@@ -133,3 +133,19 @@ and on binary format instead:
 .. note::
 
     Exporting keys will not change the status of your local keystore or keyring. This will just obtain the content of the keys and save it on a local file on your host.
+
+.. _key_remove:
+
+------------------
+Key remove command
+------------------
+
+In case you would want to remove a public key from your public local keystore, you can do so by running the following command:
+
+.. code-block:: Singularity
+
+    $ singularity key remove 8C10B902F438E4D504C3ACF689FCFFAED5F34A77
+
+.. note::
+
+    Remember that this will only delete the public key and not the private one with the same matching fingerprint.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Documentation is missing a key commands section explaining: key import, key export, key remove commands.


## This fixes or addresses the following GitHub issues:

- Fixes #142 
