### PR TITLE
Add nodeps flag to rpmbuild

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -247,6 +247,12 @@ build and install the RPM.
         sudo rpm -ivh ~/rpmbuild/RPMS/x86_64/singularity-$VERSION-1.el7.x86_64.rpm && \
         rm -rf ~/rpmbuild singularity-$VERSION*.tar.gz
 
+If you encounter a failed dependency error for golang but installed it from source, build with this command:
+
+.. code-block:: none
+    rpmbuild -tb --nodeps singularity-${VERSION}.tar.gz && \
+
+
 Options to ``mconfig`` can be passed using the familiar syntax to ``rpmbuild``.
 For example, if you want to force the local state directory to ``/mnt`` (instead
 of the default ``/var``) you can do the following:

--- a/installation.rst
+++ b/installation.rst
@@ -250,7 +250,8 @@ build and install the RPM.
 If you encounter a failed dependency error for golang but installed it from source, build with this command:
 
 .. code-block:: none
-    rpmbuild -tb --nodeps singularity-${VERSION}.tar.gz && \
+
+    rpmbuild -tb --nodeps singularity-${VERSION}.tar.gz 
 
 
 Options to ``mconfig`` can be passed using the familiar syntax to ``rpmbuild``.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Add a comment directing users to rpmbuild with nodeps if they encounter a depdency error for golang (happens when go is installed from source).


## This fixes or addresses the following GitHub issues:

- Fixes #68 
