### PR TITLE
Removing go dep section on quickstart -> 3.2

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -94,16 +94,6 @@ build Singularity from source.
     $ git clone https://github.com/sylabs/singularity.git
     $ cd singularity
 
-Install Go dependencies
-=======================
-
-Dependencies are managed using `Dep <https://github.com/golang/dep>`_. You
-can use go get to install it like so:
-
-.. code-block:: none
-
-    $ go get -u -v github.com/golang/dep/cmd/dep
-
 Compile the Singularity binary
 ==============================
 


### PR DESCRIPTION
## This fixes or addresses the following GitHub issues:

- Fixes #176 
