### PR TITLE
clarify location of cgroups example toml file

### DIFF
--- a/cgroups.rst
+++ b/cgroups.rst
@@ -13,10 +13,12 @@ Overview
 
 Singularity cgroups support can be configured and utilized via a TOML file. An
 example file is typically installed at
-``/usr/local/etc/singularity/cgroups/cgroups.toml``.  You can copy and edit this
-file to suit your needs.  Then when you need to limit your container resources,
-apply the settings in the TOML file by using the path as an argument to the
-``--apply-cgroups`` option like so:
+``/usr/local/etc/singularity/cgroups/cgroups.toml`` (but may also be installed 
+in other locations such as ``/etc/singularity/cgroups/cgroups.toml`` depending 
+on your installation method).  You can copy and edit this file to suit your 
+needs.  Then when you need to limit your container resources, apply the settings 
+in the TOML file by using the path as an argument to the ``--apply-cgroups`` 
+option like so:
 
 .. code-block:: none
 


### PR DESCRIPTION
Added clarification that cgroups example config toml may be installed in multiple locations depending on installation method

- Fixes #32 
