### PR TITLE
Add cryptsetup-bin build dependency for Singularity 3.4

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -58,7 +58,8 @@ similar with other package managers.
         libseccomp-dev \
         wget \
         pkg-config \
-        git
+        git \
+        cryptsetup-bin
 
 ``yum``
 


### PR DESCRIPTION
I just encountered a missing package when following the Singularity build instructions with the new 3.4 release. Installing `cryptsetup-bin` fixes things.