### PR TITLE
Updated a command in the Quick Start section

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -251,7 +251,7 @@ the ``capability`` command group like so:
 
 .. code-block:: none
 
-    $ singularity capability list --user dave
+    $ singularity capability list dave
 
 Container authors might also write help docs specific to a container or for an
 internal module called an ``app``. If those help docs exist for a particular


### PR DESCRIPTION
## Description of the Pull Request (PR):

The argument `--user` doesn't seem to be needed anymore by `singularity capability list`.

Also, as a very minor aside, following the quick start guide as if it was a tutorial (i.e. copying commands on the local console while reading):
```console
$ singularity capability list culpo
FATAL:   Unable to list capabilities: no capability set for user/group culpo
```
fails with an error. Since this is done to introduce command groups, I was wondering if a command that succeeds like:
```console
$ singularity cache list --verbose
NAME                     DATE CREATED           SIZE             TYPE
lolcow_latest.sif        2019-09-18 15:42:31    83.79 MB         library

There are 1 container file(s) using 83.79 MB and 0 oci blob file(s) using 0.00 kB of space
Total space used: 83.79 MB
```
would be considered a better fit. If so, I'll make this change.

## This fixes or addresses the following GitHub issues:

No open issues for this minor update.
