### PR TITLE
Removed a duplicate entry in index.rst

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -21,7 +21,6 @@ User Guide
    Running Services <running_services>
    Environment and Metadata <environment_and_metadata>
    OCI Runtime Support <oci_runtime>
-   Container Security <security>
    Key commands <key_commands>
    Sign and Verify <signNverify>
    Plugins <plugins>


### PR DESCRIPTION
The "Container Security <security>" entry was duplicated in `index.rst` and shown twice in the sidebar.