### PR TITLE
CircleCI basic setup

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,119 @@
+version: 2.1
+
+defaults: &defaults
+  docker:
+    - image: python:3.6-buster
+
+jobs:
+
+  lint_markdown:
+    <<: *defaults
+    docker:
+      - image: node:11-slim
+    steps:
+      - checkout
+      - run:
+          name: Install markdownlint
+          command: npm install -g markdownlint-cli
+      - run:
+          name: Check for Lint
+          command: markdownlint .
+
+  check_rst:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Install sphinx
+          command: |
+            pip install sphinx sphinx-rtd-theme rstcheck pygmentss
+      - run:
+          name: Lint rst
+          command: |
+            rstcheck *.rst
+
+  make_html:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Singularity submodule init
+          command: |
+            git submodule update --init --recursive
+      - run:
+          name: Install sphinx
+          command: |
+            pip install sphinx sphinx-rtd-theme restructuredtext_lint pygments
+      - run:
+          name: Install singularity deps
+          command: |
+            apt-get update -y && \
+            apt-get install -f -y build-essential libssl-dev uuid-dev squashfs-tools libseccomp-dev cryptsetup-bin libgpgme-dev
+      - run:
+          name: Install Go 1.12.9
+          command: |
+            wget https://dl.google.com/go/go1.12.9.linux-amd64.tar.gz
+            rm -rf /usr/local/go
+            tar -C /usr/local -xzf go1.12.9.linux-amd64.tar.gz
+            ln -s /usr/local/go/bin/go /usr/local/bin/go
+      - run:
+          name: make html
+          command: |
+            make html
+      - store_artifacts:
+          path: _build/html
+          destination: html
+
+  make_pdf_epub:
+    <<: *defaults
+    steps:
+      - checkout
+      - run:
+          name: Install sphinx
+          command: |
+            pip install sphinx sphinx-rtd-theme restructuredtext_lint pygments
+      - run:
+          name: submodule init
+          command: |
+            git submodule update --init --recursive
+      - run:
+          name: Install singularity deps
+          command: |
+            apt-get update -y && \
+            apt-get install -f -y build-essential libssl-dev uuid-dev squashfs-tools libseccomp-dev cryptsetup-bin libgpgme-dev
+      - run:
+          name: Install Go 1.12.9
+          command: |
+            wget https://dl.google.com/go/go1.12.9.linux-amd64.tar.gz
+            rm -rf /usr/local/go
+            tar -C /usr/local -xzf go1.12.9.linux-amd64.tar.gz
+            ln -s /usr/local/go/bin/go /usr/local/bin/go
+      - run:
+          name: Install TeXlive
+          command: |
+            apt-get install -f -y texlive-latex-extra latexmk
+      - run:
+          name: make pdf
+          command: |
+            make latexpdf
+      - store_artifacts:
+          path: _build/latex
+          destination: pdf
+      - run:
+          name: make epub
+          command: |
+            make epub
+      - store_artifacts:
+          path: _build/epub
+          destination: epu
+
+workflows:
+  version: 2
+  build_and_test:
+    jobs:
+      - lint_markdown
+      - check_rst
+      - make_html
+      - make_pdf_epub
+
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Lint rst
           command: |
-            rstcheck *.rst
+            rstcheck --report warning *.rst
 
   make_html:
     <<: *defaults

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -113,7 +113,10 @@ workflows:
     jobs:
       - lint_markdown
       - check_rst
-      - make_html
-      - make_pdf_epub
-
+      - make_html:
+          requires:
+            - check_rst
+      - make_pdf_epub:
+          requires:
+            - check_rst
 

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,7 +26,7 @@ jobs:
       - run:
           name: Install sphinx
           command: |
-            pip install sphinx sphinx-rtd-theme rstcheck pygmentss
+            pip install sphinx sphinx-rtd-theme rstcheck pygments
       - run:
           name: Lint rst
           command: |

--- a/README.md
+++ b/README.md
@@ -1,77 +1,94 @@
 # Singularity User Docs
 
-This project uses <a href="http://docutils.sourceforge.net/rst.html"> reStructured Text (RST)</a> and <a href="https://readthedocs.org/">ReadTheDocs </a> . As a library for the current theme,  <a href="https://pypi.org/project/Sphinx/" alt="PyPI">Sphinx Python library </a> was used, using Python v. 2.7.
-**********************************************************************************************************************************************************************************************************************************************************************************************************************************************************************
-## I want to contribute, how can I set up my environment? ###
+This project uses <a href="http://docutils.sourceforge.net/rst.html">
+reStructured Text (RST)</a> and <a href="https://readthedocs.org/">ReadTheDocs
+</a> . As a library for the current theme, <a
+href="https://pypi.org/project/Sphinx/" alt="PyPI">Sphinx Python library </a>
+was used, using Python v. 2.7.
 
+## Setting up an environment to contribute
 
 First things first, you will need to install the following tools:
 
 - <a href="https://www.python.org/download/releases/2.7/">Install Python 2.7</a>
 - After that then you will need to install Sphinx:
 
-```
+```sh
 pip install -U Sphinx
 ```
 
-You're all set! after this you will only need to use your favorite editor for RST files.
+You're all set! after this you will only need to use your favorite editor for
+RST files.
 
-## How to do stuff on RST? ###
+## How to edit & write RST
 
-First of all, it is good to have an idea of some files and their functionality into the project:
+First of all, it is good to have an idea of some files and their functionality
+into the project:
 
-### **Structure of the project**
+### Structure of the project
 
 This project maintains the following structure:
 
-1. Index.rst : contains the sections and the initial table of contents tree, every section is referenced by a tag next to it. (e.g. ``Quick Start <quick_start>``)
-2. All other files, are named as the same reference tag described before, so in the previous example, a correspondent ``quick_start.rst`` file exists.
-3. The configuration at the moment of compilation is given by the ``conf.py`` file, some more description about this file can be found below.
+1. Index.rst : contains the sections and the initial table of contents tree,
+   every section is referenced by a tag next to it. (e.g. ``Quick Start
+   <quick_start>``)
+2. All other files, are named as the same reference tag described before, so in
+   the previous example, a correspondent ``quick_start.rst`` file exists.
+3. The configuration at the moment of compilation is given by the ``conf.py``
+   file, some more description about this file can be found below.
 
-### **The conf.py file**
+### The conf.py file
 
-This file contains the themes, extensions, variables and naming for files that the compilation process produces. Some important elements are the following:
+This file contains the themes, extensions, variables and naming for files that
+the compilation process produces. Some important elements are the following:
 
-- ``version`` : Describes the current version (This one is a short version of the release)
-- ``release``: Describes the current release (Complete or full version description. For a matter of simplicity we maintain both at the same value)
+- ``version`` : Describes the current version (This one is a short version of
+  the release)
+- ``release``: Describes the current release (Complete or full version
+  description. For a matter of simplicity we maintain both at the same value)
 
-- ``html_theme``: Describes the theme to be used in the ``ReadtheDocs`` document.
-- ``html_theme_options``: Describes the options needed for configuration in the theme (This varies from theme to theme, so we enforce using the options for the ``Sphinx theme`` only.
-- ``html_context``: Options related to which is the github repository and what name it has.
+- ``html_theme``: Describes the theme to be used in the ``ReadtheDocs``
+  document.
+- ``html_theme_options``: Describes the options needed for configuration in the
+  theme (This varies from theme to theme, so we enforce using the options for
+  the ``Sphinx theme`` only.
+- ``html_context``: Options related to which is the github repository and what
+  name it has.
 - ``html_logo``: The logo for the sidebar
 - ``html_favicon``: The ``favicon`` for the entire project
-- ``htmlhelp_basename``: Default name of the document generated in Latex, we leave all these as default values.
+- ``htmlhelp_basename``: Default name of the document generated in Latex, we
+  leave all these as default values.
 
-### **Cheatsheet to get started with reStructured (RST) Text**
+### Cheatsheet to get started with reStructured (RST) Text
 
 Some hints on how to write stuff on RST are described in this section.
 
-#### **1. Create a section/subsection/subsubsection title**
+#### 1. Create a section/subsection/subsubsection title
 
-Sections are all described as plain text, but have specific notations/underlining for titles and subtitles, very similar to Markup Language.
+Sections are all described as plain text, but have specific
+notations/underlining for titles and subtitles, very similar to Markup Language.
 
-- To create a main section title: A main section title is described as a surrounded text (above and below) of ``=`` characters. Like in the following example:
+- To create a main section title: A main section title is described as a
+  surrounded text (above and below) of ``=`` characters. Like in the following
+  example:
 
 ```sh
-
 ================
 New Main Section
 ================
-
 ```
 
-- To create a sub-section: A sub section title is described as a surrounded text (above and below) of ``-`` characters. Like in the following example:
+- To create a sub-section: A sub section title is described as a surrounded text
+  (above and below) of ``-`` characters. Like in the following example:
 
 ```sh
-
 ---------------
 New Sub section
 ---------------
-
 ```
 
-- To create a sub-sub-section: A sub-sub section title is described as a text underlined by ``=`` characters. Like in the following example:
-
+- To create a sub-sub-section: A sub-sub section title is described as a text
+  underlined by ``=`` characters. Like in the following example:
 
 ```sh
 
@@ -80,97 +97,117 @@ New sub-sub section
 
 ```
 
-- Last but not least, could happen that you would need to insert a sub-sub-sub section, in that case the title is described as a text underlined by ``-`` characters. Like in the following example:
-
+- Last but not least, could happen that you would need to insert a sub-sub-sub
+  section, in that case the title is described as a text underlined by ``-``
+  characters. Like in the following example:
 
 ```sh
-
 New sub-sub-sub section
 -----------------------
-
 ```
 
-#### **2. Reference sections**
+#### 2. Reference sections
 
-You might need to reference sections, for that aim you will need to first create the reference above the title you need to reference and second to reference it where you need the link reference. Remember that this type of references is very different than that of hyperlinks, because at the moment of compilation, the latex document generated will have the reference to the page in which that title was referenced. Very cool, huh? Let's see how it works...
+You might need to reference sections, for that aim you will need to first create
+the reference above the title you need to reference and second to reference it
+where you need the link reference. Remember that this type of references is very
+different than that of hyperlinks, because at the moment of compilation, the
+latex document generated will have the reference to the page in which that title
+was referenced. Very cool, huh? Let's see how it works...
 
-##### **Step 1: Create the reference**
+##### Step 1: Create the reference
 
-To create the reference on the section you need to link, you will need to specify a tag, allowed characters contain also ``-`` characters but they need to be unique name tags. So for example, in the build-docker-module section we can have something like:  
+To create the reference on the section you need to link, you will need to
+specify a tag, allowed characters contain also ``-`` characters but they need to
+be unique name tags. So for example, in the build-docker-module section we can
+have something like:
 
 ```sh
-
 .. _build-docker-module:
 
 -------------------
 build-docker-module
 -------------------
-
-
 ```
 
-Note that it might not be necessarily that the section is called just as the same as the tag-name.
+Note that it might not be necessarily that the section is called just as the
+same as the tag-name.
 
-##### **Step 2: Reference it!**
+##### Step 2: Reference it
 
 You can do so by following the next syntax:
 
-The name after the ref tag could also be different, the important thing is that the tag between the ``<`` and ``>`` is the one that belongs to the previous given tag name. Like in the following example:
+The name after the ref tag could also be different, the important thing is that
+the tag between the ``<`` and ``>`` is the one that belongs to the previous
+given tag name. Like in the following example:
 
 ```sh
-
 :ref:`quickstart <quick-start>`
-
-
 ```
 
+You can find a lot of information about RST on <a
+href="http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html">this
+site</a>
 
+### Generating HTML files from RST
 
-You can find a lot of information about RST on <a href="http://docutils.sourceforge.net/docs/ref/rst/restructuredtext.html">this site</a>
+This is pretty straightforward by going to the root of the project on the
+command line and then do:
 
-### How to generate the HTML files from RST files? ###
-
-This is pretty straightforward by going to the root of the project on the command line and then do:
-
-```
+```sh
 make html SKIPCLI=1
 ```
-This will generate a folder called **_build** which inside will have a folder called **html** containing all the html files you need.
 
-### How to generate PDF files? ###
+This will generate a folder called **_build** which inside will have a folder
+called **html** containing all the html files you need.
+
+### Generating PDF files from RST
 
 This is very similar to the previous step, you will need to execute on command line:
 
-```
+```sh
 make latexpdf SKIPCLI=1
 ```
-with this, a new folder inside **_build** will be generated, called **latex** and in there you can find the `pdf` file generated from `RST` (by default it is called "ReadTheDocsTemplate.pdf").
+
+with this, a new folder inside **_build** will be generated, called **latex**
+and in there you can find the `pdf` file generated from `RST` (by default it is
+called "ReadTheDocsTemplate.pdf").
 
 (Additional latex files are also generated if needed.)
 
-### How to generate the EPUB files? ###
+### Generating EPUB from RST
 
-Very similar to the previous command, you will just need to execute on a command line:
+Very similar to the previous command, you will just need to execute on a command
+line:
 
-```
+```sh
 make epub SKIPCLI=1
 ```
 
-This will generate an **epub** folder inside **_build** folder. Inside you will find the file with an `epub` extension.
+This will generate an **epub** folder inside **_build** folder. Inside you will
+find the file with an `epub` extension.
 
-## How are the CLI docs generated?
+## Generating CLI docs
+
 The Singularity CLI docs are generated using the actual code from Singularity.
-To do this, we include Singularity as a submodule, and whenever a Makefile target (like `make html`) is run, Singularity itself is compiled and used to generate the CLI docs.
+To do this, we include Singularity as a submodule, and whenever a Makefile
+target (like `make html`) is run, Singularity itself is compiled and used to
+generate the CLI docs.
 
-However, you might not want to compile Singularity, either because you can't on your machine, or because you want to test out a quick change to the docs.
-If this is the case, you can skip the CLI doc generation using the `SKIPCLI` argument.
-For example, to rebuild the HTML docs without including the CLI docs, just run `make html SKIPCLI=1`.
+However, you might not want to compile Singularity, either because you can't on
+your machine, or because you want to test out a quick change to the docs.  If
+this is the case, you can skip the CLI doc generation using the `SKIPCLI`
+argument.  For example, to rebuild the HTML docs without including the CLI docs,
+just run `make html SKIPCLI=1`.
 
-If Singularity has been updated and you want to synchronize the CLI docs with the new version of Singularity, you'll have to update the submodule.
-To do this, just run:
+If Singularity has been updated and you want to synchronize the CLI docs with
+the new version of Singularity, you'll have to update the submodule.  To do
+this, just run:
+
 ```bash
 git submodule update --remote --merge
 git add vendor/src/github.com/sylabs/singularity
 git commit
 ```
+
 This will update the Singularity submodule to the latest version of the master branch.

--- a/appendix.rst
+++ b/appendix.rst
@@ -770,7 +770,7 @@ zypper build module is ``zypper`` itself.
 .. _docker-daemon-archive:
 
 ``docker-daemon & docker-archive`` bootstrap agents
-^^^^^^^^^^^^^^^^^^^^^^^^^^^
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 For users using docker locally there are two options for creating Singularity
 images without the need for a repository: ``docker-daemon://`` and ``docker-archive://``

--- a/build_env.rst
+++ b/build_env.rst
@@ -5,6 +5,7 @@ Build Environment
 =================
 
 .. _sec:buildenv:
+
 --------
 Overview
 --------

--- a/contributing.rst
+++ b/contributing.rst
@@ -44,7 +44,7 @@ For general bugs/issues, you can open an issue `at the GitHub repo
 security  related issue/problem, please email Sylabs directly at 
 `security@sylabs.io <mailto:security@sylabs.io>`_. More information about the 
 Sylabs security policies and procedures can be found `here 
-<https://www.sylabs.io/singularity/security-policy/>`_
+<https://www.sylabs.io/singularity/security-policy/>`__
 
 -------------------
 Write Documentation
@@ -74,7 +74,7 @@ Other dependencies include:
 More information about contributing to the documentation, instructions on how to 
 install the dependencies, and how to generate the files can be obtained 
 `here 
-<https://github.com/sylabs/singularity-userdocs/blob/master/README.md#singularity-user-docs>`_.
+<https://github.com/sylabs/singularity-userdocs/blob/master/README.md#singularity-user-docs>`__.
 
 For more information on using Git and GitHub to create a pull request suggesting 
 additions and edits to the docs, see the :ref:`section on contributing to the

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -470,7 +470,7 @@ helpful to know where they are and what they do:
    later versions of Singularity, these files may be dynamically written at
    runtime.
 
--  **env**: All *.sh files in this directory are sourced in alpha-numeric order
+-  **env**: All ``*.sh`` files in this directory are sourced in alpha-numeric order
    when the container is initiated. For legacy purposes there is a symbolic link
    called ``/environment`` that points to
    ``/.singularity.d/env/90-environment.sh``.

--- a/installation.rst
+++ b/installation.rst
@@ -405,7 +405,7 @@ misconception, Mac does not run on a Linux kernel.  It runs on a kernel called
 Darwin originally forked from BSD.)
 
 For this reason, the Singularity community maintains a set of Vagrant Boxes via
-`Vagrant Cloud <https://www.vagrantup.com/>`_, one of `Hashicorp's
+`Vagrant Cloud <https://www.vagrantup.com/>`__, one of `Hashicorp's
 <https://www.hashicorp.com/#open-source-tools>`_ open source tools. The current
 versions can be found under the `sylabs <https://app.vagrantup.com/sylabs>`_
 organization.
@@ -436,8 +436,8 @@ Mac
 
 With Singularity Desktop for macOS (Alpha Preview):
 
-The disk image file is available `here <http://repo.sylabs.io/desktop/singularity-desktop-0.0.1alpha.dmg>`_.
-More information can be found `here <https://www.sylabs.io/singularity-desktop-macos/>`_.
+The disk image file is available `here <http://repo.sylabs.io/desktop/singularity-desktop-0.0.1alpha.dmg>`__.
+More information can be found `here <https://www.sylabs.io/singularity-desktop-macos/>`__.
 
 Singularity is also available via Vagrant (installable with
 `Homebrew <https://brew.sh>`_ or manually) or with the Singularity Desktop for

--- a/mpi.rst
+++ b/mpi.rst
@@ -1,16 +1,16 @@
-.. _mpi
+.. _mpi:
 
 ================================
 Singularity and MPI applications
 ================================
 
-.. _sec:mpi
+.. _sec-mpi:
 
 The `Message Passing Interface (MPI) <https://mpi-forum.org>`_
 is a standard extensively used by HPC applications to implement various communication
 across compute nodes of a single system or across compute platforms.
 There are two main open-source implementations of MPI at the
-moment - `OpenMPI <https://www.open-mpi.org//>`_ and `MPICH <https://www.mpich.org/>`_,
+moment - `OpenMPI <https://www.open-mpi.org/>`_ and `MPICH <https://www.mpich.org/>`_,
 both of which are supported by Singularity. The goal of this page is to
 demonstrate the development and running of MPI programs using Singularity containers.
 

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -433,7 +433,7 @@ Running a container
 Singularity containers contain :ref:`runscripts <runscript>`. These are user
 defined scripts that define the actions a container should perform when someone
 runs it. The runscript can be triggered with the `run <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_run.html>`_
- command, or simply by calling the container as though it were an executable.
+command, or simply by calling the container as though it were an executable.
 
 .. code-block:: none
 

--- a/security.rst
+++ b/security.rst
@@ -60,7 +60,7 @@ Admin Configurable Files
 Singularity Administrators will have the ability to access various configuration files, that will let them set security 
 restrictions, grant or revoke a user’s capabilities, manage resources and authorize containers etc. One such file interesting in this context is `ecl.toml <https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html#ecl-toml>`_ 
 which allows blacklisting and whitelisting of containers. However, you should find all the configuration files and their parameters
-documented `here <https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html>`_. 
+documented `here <https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html>`__. 
 
 cgroups support
 ****************
@@ -70,14 +70,14 @@ without the help of a separate program like a batch scheduling system. This feat
 container seizes control of all available system resources in order to stop other containers from operating properly. 
 To utilize this feature, a user first creates a configuration file. An example configuration file is installed by default with 
 Singularity to provide a guide. At runtime, the ``--apply-cgroups`` option is used to specify the location of the configuration 
-file and cgroups are configured accordingly. More about cgroups support `here <https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html#cgroups-toml>`_.
+file and cgroups are configured accordingly. More about cgroups support `here <https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html#cgroups-toml>`__.
 
 ``--security`` options
 ***********************
 
 Singularity supports a number of methods for specifying the security scope and context when running Singularity containers. 
 Additionally, it supports new flags that can be passed to the action commands; ``shell``, ``exec``, and ``run`` allowing fine 
-grained control of security. Details about them are documented `here <https://sylabs.io/guides/\{version\}/user-guide/security_options.html>`_.
+grained control of security. Details about them are documented `here <https://sylabs.io/guides/\{version\}/user-guide/security_options.html>`__.
 
 Security in SCS
 ################

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -1943,4 +1943,5 @@ Section          Description                Section          Description
                                                              | key-value pair.
 
 ================ ========================== ================ =============================
+
 .. TODO-ND SIFtool - does it have more to offer here???


### PR DESCRIPTION
Add a basic CircleCI configuration that will...

- Lint the `README.md` with `markdown lint`
- Check the `rst` files for issues with `rstcheck` (warnings + errors only)
- Build the html pages and save as an `html` artefact so they can be browsed in PRs etc.
- Build the pdf and epub and save as artefacts so they can be examined in a PR etc.

Also includes fixes for markdown lint, and rst warnings/errors.

<img width="497" alt="image" src="https://user-images.githubusercontent.com/4522799/65538692-7854dc00-decd-11e9-9123-0c1d16338d24.png">
