### PR TITLE
Bump 2.5 install VER to 2.5.2

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -92,7 +92,7 @@ releases <https://github.com/sylabs/singularity/releases>`_ page to ``/usr/local
 
 .. code-block:: none
 
-    $ VER=2.5.1
+    $ VER=2.5.2
 
     $ wget https://github.com/sylabs/singularity/releases/download/$VER/singularity-$VER.tar.gz
 


### PR DESCRIPTION
## Description of the Pull Request (PR):

Make the 2.5 docs refer to the latest/last 2.5.2 release in that series


## This fixes or addresses the following GitHub issues:

- Fixes #135 

(See comment on #135 why autogen.sh is not required)
