### PR TITLE
Fix #201 - Note instance names cannot have hyphens in 2.x

### DIFF
--- a/running_services.rst
+++ b/running_services.rst
@@ -64,6 +64,12 @@ for the container instances’ processes/services to live inside. We can
 confirm that this command started an instance by running the
 instance.list command like so:
 
+.. note::
+   
+   In Singularity 2.x the name of an instance *must not* contain a ``-`` (hyphen)
+   character. This restriction is not present in Singularity 3.x
+
+
 .. code-block:: none
 
     $ singularity instance.list


### PR DESCRIPTION
## Description of the Pull Request (PR):

Note instance names cannot have a hyphen in 2.6

![Screenshot at 2019-10-02 12-53-14](https://user-images.githubusercontent.com/4522799/66068813-e3c52c00-e513-11e9-9b4b-99f1c9241480.png)

## This fixes or addresses the following GitHub issues:

- Fixes #201 

Note - this won't pass CI - we don't have the proper setup on 2.x as I don't want to go and fix lint etc. in the historic docs.
