### PR TITLE
Added another dependency

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -56,6 +56,7 @@ similar with other package managers.
         libgpgme-dev \
         squashfs-tools \
         libseccomp-dev \
+        cryptsetup-bin \
         wget \
         pkg-config \
         git \


### PR DESCRIPTION
On Ubuntu cryptsetup-bin isn't always installed by default. Just running the previous set of instructions with a fresh install of Ubuntu 19.04 led to an error stating cryptsetup couldn't be found.
