### PR TITLE
Corrected filename. Removed references to v2

### DIFF
--- a/persistent_overlays.rst
+++ b/persistent_overlays.rst
@@ -51,7 +51,7 @@ system image:
 .. code-block:: none
 
     $ dd if=/dev/zero of=my_overlay bs=1M count=500 && \
-        mkfs.ext3 my-overlay
+        mkfs.ext3 my_overlay
 
 The second example creates an ext3 file system image with 500MBs of empty space.
 
@@ -110,15 +110,7 @@ will be gone.
 
     Singularity ubuntu.sif:~> exit
 
-------------------------------
-A note on resizing ext3 images
-------------------------------
-
-Singularity v2 provided built-in support for creating and resizing ext3 file 
-system images, but with the adoption of SIF as the default container format,
-this support was dropped.  
-
-Luckily, you can use standard Linux tools to manipulate ext3 images. For
+To resize an overlay, standard Linux tools which manipulate ext3 images can be used.  For
 instance, to resize the 500MB file created above to 700MB one could use the 
 ``e2fsck`` and ``resize2fs`` utilities like so:
 


### PR DESCRIPTION
There is an error where a dash is used instead of an underline in my_overlay.

I removed references to v2 as it just confused me.  These are optional changes, of course :)

The mkfs.ext3 command shows a warning and a prompt when I run it.  Maybe that should be documented?
```
> mkfs.ext3 my_overlay
500+0 records in
500+0 records out
524288000 bytes (524 MB) copied, 1.4015 s, 374 MB/s
mke2fs 1.42.9 (28-Dec-2013)
my_overlay is not a block special device.
Proceed anyway? (y,n) 
```

OS is CentOS 7

## Description of the Pull Request (PR):

Corrected filename.  Suggested new text relating to Singularity 2.
