### PR TITLE
Ignore c / c++ code blocks in rst_check

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -30,7 +30,7 @@ jobs:
       - run:
           name: Lint rst
           command: |
-            rstcheck --report warning *.rst
+            rstcheck --ignore-language c,c++ --report warning *.rst
 
   make_html:
     <<: *defaults


### PR DESCRIPTION
## Description of the Pull Request (PR):

Currently, rst_check fails as the MPI example
code is referencing <mpi.h> which is not available in the CI
environment. Avoid linting the embedded c / c++ blocks.

## This fixes or addresses the following GitHub issues:

- Fixes #266 
