### PR TITLE
Note that cryptsetup is not a hard build dep

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -77,6 +77,11 @@ similar with other package managers.
 
 .. _install-go:
 
+.. note::
+
+   You can build Singularity (3.5+) without ``cryptsetup`` available, but will
+   not be able to use encrypted containers without it installed on your system.
+
 ----------
 Install Go
 ----------


### PR DESCRIPTION
## Description of the Pull Request (PR):

Can build without cryptsetup but need it to use encryption.

## This fixes or addresses the following GitHub issues:

- Fixes #279 
