### PR TITLE
recommend installing go 1.13 in the quickstart

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -80,7 +80,7 @@ page). Alternatively, follow the commands here:
 
 .. code-block:: none
 
-    $ export VERSION=1.12 OS=linux ARCH=amd64 && \  # Replace the values as needed
+    $ export VERSION=1.13 OS=linux ARCH=amd64 && \  # Replace the values as needed
       wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \ # Downloads the required Go package
       sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \ # Extracts the archive
       rm go$VERSION.$OS-$ARCH.tar.gz    # Deletes the ``tar`` file


### PR DESCRIPTION
The quickstart installation instructions for Singularity 3.5 include this snippet:

```
$ export VERSION=1.12 OS=linux ARCH=amd64 && \  # Replace the values as needed
  wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \ # Downloads the required Go package
  sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \ # Extracts the archive
  rm go$VERSION.$OS-$ARCH.tar.gz    # Deletes the ``tar`` file
```
...but Singularity 3.5 will not compile with version 1.12 of go, it requires at least 1.13.
