### PR TITLE
Update quick_start.rst

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -80,7 +80,7 @@ page). Alternatively, follow the commands here:
 
 .. code-block:: none
 
-    $ export VERSION=1.12 OS=linux ARCH=amd64 && \  # Replace the values as needed
+    $ export VERSION=1.13 OS=linux ARCH=amd64 && \  # Replace the values as needed
       wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \ # Downloads the required Go package
       sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \ # Extracts the archive
       rm go$VERSION.$OS-$ARCH.tar.gz    # Deletes the ``tar`` file


### PR DESCRIPTION
GO version 1.12 -> 1.13

This prevents a difficulty with installing the wrong GO version, then updating by installing the required version (the mconfig file fails to find the newer GO version).

Given the installer for Singularity 3.5 now requires GO 1.13 it makes sense for this to be the default.