### PR TITLE
Bump install version for Go to 1.13.5

### DIFF
--- a/installation.rst
+++ b/installation.rst
@@ -99,7 +99,7 @@ page).
 
 .. code-block:: none
 
-    $ export VERSION=1.12 OS=linux ARCH=amd64 && \
+    $ export VERSION=1.13.5 OS=linux ARCH=amd64 && \
         wget https://dl.google.com/go/go$VERSION.$OS-$ARCH.tar.gz && \
         sudo tar -C /usr/local -xzvf go$VERSION.$OS-$ARCH.tar.gz && \
         rm go$VERSION.$OS-$ARCH.tar.gz


### PR DESCRIPTION
## Description of the Pull Request (PR):

Bump install version for Go to 1.13.5

## This fixes or addresses the following GitHub issues:

 - Fixes: #283
