### PR TITLE
Correct in memory encryption statement

### DIFF
--- a/security_options.rst
+++ b/security_options.rst
@@ -81,9 +81,9 @@ Of course appropriate caution should be exercised when using this keyword.
 Building encrypted containers
 -----------------------------
 Beginning in Singularity 3.4.0 it is possible to build and run encrypted
-containers.  The containers are decrypted at runtime entirely in kernel space, 
-meaning that no intermediate decrypted data is ever present on disk or in 
-memory.  See :ref:`encrypted containers <encryption>` for more details.
+containers.  The containers are decrypted at runtime entirely in kernel space,
+meaning that there is no intermediate decrypted directory on disk.
+See :ref:`encrypted containers <encryption>` for more details.
 
 
 -------------------------------


### PR DESCRIPTION
## Description of the Pull Request (PR):

In memory part of encryption statement in the 3.4 docs is potentially misleading, so remove it. It was intended to indicate the container isn't _decrypted entirely into RAM before being run_. However, caching etc. and the need to run decrypted code means there is content in RAM - so the wording is misleading.