### PR TITLE
Document new 3.7 features (batch1)

### DIFF
--- a/_build/html/_static/css/custom.css
+++ b/_build/html/_static/css/custom.css
@@ -1,7 +1,0 @@
-/*
- Add the corresponding max size (500px) to code blocks and allow vertical scrollbar
-*/
-.highlight{
-  max-height: 500px;
-  overflow-y: scroll;
-}

--- a/_build/html/_static/js/ga.js
+++ b/_build/html/_static/js/ga.js
@@ -1,9 +1,0 @@
-document.write('<!-- Global site tag (gtag.js) - Google Analytics -->\
-<script async src="https://www.googletagmanager.com/gtag/js?id=UA-142263760-1"></script>\
-<script>\
-window.dataLayer = window.dataLayer || [];\
-function gtag(){dataLayer.push(arguments);}\
-gtag("js", new Date());\
-gtag("config", "UA-142263760-1");\
-</script>\
-');

--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -37,6 +37,31 @@ configuration, the system default bind points are ``$HOME`` , ``/sys:/sys`` ,
 ``/etc/passwd:/etc/passwd``, and ``$PWD``. Where the first path before ``:``
 is the path from the host and the second path is the path in the container.
 
+Disabling System Binds
+======================
+
+The ``--no-mount`` flag, added in Singularity 3.7, allows specific
+system mounts to be disabled, even if they are set in the
+``singularity.conf`` configuration file by the administrator.
+
+For example, if Singularity has been configured with ``mount hostfs =
+yes`` then every filesystem on the host will be bind mounted to the
+container by default. If, e.g. a ``/project`` filesystem on your host
+conflicts with a ``/project`` directory in the container you are
+running, you can disable the ``hostfs`` binds:
+
+.. code:: console
+
+    $ singularity run --no-mount hostfs mycontainer.sif
+
+    
+Multiple mounts can be disabled by specifying them separated by
+commas:
+
+.. code:: console
+
+    $ singularity run --no-mount tmp,sys,dev mycontainer.sif
+
 -----------------------
 User-defined bind paths
 -----------------------

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -432,8 +432,8 @@ section in a definition file:
 
 .. code-block:: singularity
 
-    Bootstrap: docker
-    From: ubuntu: latest
+    Bootstrap: library
+    From: ubuntu:latest
 
     %labels
       OWNER Joana
@@ -453,20 +453,17 @@ other metadata that were added to your container when it was built.
 Running inspect without any options, or with the ``-l`` or
 ``--labels`` options will display any labels set on the container
 
-.. code-block:: none
+.. code-block:: console
 
-    $ singularity inspect jupyter.sif
-        {
-            "OWNER": "Joana"
-            "org.label-schema.build-date": "Friday_21_December_2018_0:49:50_CET",
-            "org.label-schema.schema-version": "1.0",
-            "org.label-schema.usage": "/.singularity.d/runscript.help",
-            "org.label-schema.usage.singularity.deffile.bootstrap": "library",
-            "org.label-schema.usage.singularity.deffile.from": "debian:9",
-            "org.label-schema.usage.singularity.runscript.help": "/.singularity.d/runscript.help",
-            "org.label-schema.usage.singularity.version": "3.0.1-236.g2453fdfe"
-        }
-
+    $ singularity inspect ubuntu.sif 
+    OWNER: Joana
+    org.label-schema.build-arch: amd64
+    org.label-schema.build-date: Thursday_12_November_2020_10:51:59_CST
+    org.label-schema.schema-version: 1.0
+    org.label-schema.usage.singularity.deffile.bootstrap: library
+    org.label-schema.usage.singularity.deffile.from: ubuntu:latest
+    org.label-schema.usage.singularity.version: 3.7.0-rc.1
+                
 We can easily see when the container was built, the source of the base
 image, and the exact version of Singularity that was used to build it.
 
@@ -650,20 +647,31 @@ This flag gives you the possibility to output your labels in a JSON format.
 
 You can call it this way:
 
-.. code-block:: none
+.. code-block:: console
 
-    $ singularity inspect --json jupyter.sif
+    $ singularity inspect --json ubuntu.sif
 
 And the output would look like:
 
-.. code-block:: none
+.. code-block:: json
 
     {
-	     "attributes": {
-		     "labels": "{\n\t\"org.label-schema.build-date\": \"Friday_21_December_2018_0:49:50_CET\",\n\t\"org.label-schema.schema-version\": \"1.0\",\n\t\"org.label-schema.usage\": \"/.singularity.d/runscript.help\",\n\t\"org.label-schema.usage.singularity.deffile.bootstrap\": \"library\",\n\t\"org.label-schema.usage.singularity.deffile.from\": \"debian:9\",\n\t\"org.label-schema.usage.singularity.runscript.help\": \"/.singularity.d/runscript.help\",\n\t\"org.label-schema.usage.singularity.version\": \"3.0.1-236.g2453fdfe\"\n}"
-	     },
-	     "type": "container"
+            "data": {
+                    "attributes": {
+                            "labels": {
+                                    "OWNER": "Joana",
+                                    "org.label-schema.build-arch": "amd64",
+                                    "org.label-schema.build-date": "Thursday_12_November_2020_10:51:59_CST",
+                                    "org.label-schema.schema-version": "1.0",
+                                    "org.label-schema.usage.singularity.deffile.bootstrap": "library",
+                                    "org.label-schema.usage.singularity.deffile.from": "ubuntu:latest",
+                                    "org.label-schema.usage.singularity.version": "3.7.0-rc.1"
+                            }
+                    }
+            },
+            "type": "container"
     }
+
 
 -------------------------
 /.singularity.d directory

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -438,6 +438,37 @@ section in a definition file:
     %labels
       OWNER Joana
 
+      
+Dynamic Build Time Labels
+-------------------------
+
+You may wish to set a label to a value that is not known in advance,
+when you are writing the definition file, but can be obtained in the
+``%post`` section of your definition file while the container is
+building.
+
+Singularity 3.7 and above allow this, through adding labels to the
+file defined by the ``SINGULARITY_LABELS`` environment variable in the
+``%post`` section:
+
+.. code-block:: singularity
+               
+    Bootstrap: library
+    From: ubuntu:latest
+
+    # These labels take a fixed value in the definition
+    %labels
+      OWNER Joana
+
+    # We can now also set labels to a value at build time
+    %post
+      VAL="$(myprog --version)"
+      echo "my.label $VAL" >> "$SINGULARITY_LABELS"
+
+Labels must be added to the file one per line, in a ``NAME VALUE`` format,
+where the name and value are separated by a space.
+
+
 Inspecting Metadata
 -------------------
 
@@ -456,6 +487,7 @@ Running inspect without any options, or with the ``-l`` or
 .. code-block:: console
 
     $ singularity inspect ubuntu.sif 
+    my.label: version 1.2.3
     OWNER: Joana
     org.label-schema.build-arch: amd64
     org.label-schema.build-date: Thursday_12_November_2020_10:51:59_CST
@@ -659,6 +691,7 @@ And the output would look like:
             "data": {
                     "attributes": {
                             "labels": {
+                                    "my.label": "version 1.2.3",
                                     "OWNER": "Joana",
                                     "org.label-schema.build-arch": "amd64",
                                     "org.label-schema.build-date": "Thursday_12_November_2020_10:51:59_CST",

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -26,9 +26,9 @@ specify your own to be recorded against your container.
 Changes in Singularity 3.6
 --------------------------
 
-Singularity 3.6 has modified the ways in which environment variables
+Singularity 3.6 modified the ways in which environment variables
 are handled to allow long-term stability and consistency that has
-been lacking in prior versions. It also introduces new ways of setting
+been lacking in prior versions. It also introduced new ways of setting
 environment variables, such as the ``--env`` and ``--env-file``
 options.
 
@@ -370,6 +370,41 @@ environment is constructed in the following order:
   - Inject ``SINGULARITYENV_`` / ``--env`` / ``--env-file`` variables
     so they can override or modify any previous values:
   - Source any remaining scripts from ``/singularity.d/env`` 
+
+
+.. _sec:umask:
+
+
+--------------------------------
+Umask / Default File Permissions
+--------------------------------
+
+The ``umask`` value on a Linux system controls the default permissions
+for newly created files. It is not an environment variable, but
+influences the behavior of programs in the container when they create
+new files.
+
+.. note::
+
+   A detailed description of what the ``umask`` is, and how it works
+   can be found at `Wikipedia
+   <https://en.wikipedia.org/wiki/Umask>`__.
+
+   
+Singularity 3.7 and above set the ``umask`` in the container to match
+the value outside, unless:
+
+  - The ``--fakeroot`` option is used, in which case a ``0022`` umask
+    is set so that ``root`` owned newly created files have expected
+    'system default' permissions, and can be accessed by other
+    non-root users who may use the same container later.
+  - The ``--no-umask`` option is used, in which case a ``0022`` umask
+    is set.
+
+.. note::
+
+   In Singularity 3.6 and below a default ``0022`` umask was always applied.
+
 
 .. _sec:metadata:
 


### PR DESCRIPTION
Document dynamic build time labels
    
 - Closes #362

Show new build-arch label in metadata examples
    
 - Closes #360

Add `--no-mount` description
    
 - Closes #365

Add umask information
    
 - Closes #366
