### PR TITLE
Document new 3.7 features (batch2)

### DIFF
--- a/cloud_library.rst
+++ b/cloud_library.rst
@@ -40,7 +40,7 @@ Access tokens for pushing a container, and remote builder.
 To generate a access token, do the following steps:
 
   1) Go to: https://cloud.sylabs.io/
-  2) Click "Sign in to Sylabs" and follow the sign in steps.
+  2) Click "Sign In" and follow the sign in steps.
   3) Click on your login id (same and updated button as the Sign in one).
   4) Select "Access Tokens" from the drop down menu.
   5) Enter a name for your new access token, such as "test token"

--- a/cloud_library.rst
+++ b/cloud_library.rst
@@ -144,38 +144,102 @@ Check out :ref:`this page <signNverify>` on how to: :ref:`verify a container <ve
 Searching the Library for Containers
 ------------------------------------
 
-When it comes to searching the library, you could always go to: https://cloud.sylabs.io/library and search from there
-through the web GUI. Or you can use ``singularity search <container/user>``, this will search the library for
-the ``<container/user>``.
+To find interesting or useful containers in the library, you can open
+https://cloud.sylabs.io/library in your browser and search from there
+through the web GUI.
+
+Alternatively, from the CLI you can use ``singularity search
+<query>``. This will search the library for container images matching
+``<query>``.
 
 Using the CLI Search
 --------------------
 
-Here is an example for searching the library for ``centos``:
+Here is an example of searching the library for ``centos``:
 
-.. code-block:: none
+.. code-block:: console
 
-    $ singularity search centos
-    No users found for 'centos'
-    
-    No collections found for 'centos'
-    
-    Found 6 containers for 'centos'
-    	library://dtrudg/linux/centos
-    		Tags: 6 7 centos6 centos7 latest
-    	library://library/default/centos
-    		Tags: 6 7 latest
-    	library://gmk/demo/centos-vim
-    		Tags: latest
-    	library://mroche/baseline/centos
-    		Tags: 7 7.5 7.5.1804 7.6 7.6.1810 latest
-    	library://gmk/default/centos7-devel
-    		Tags: latest
-    	library://emmeff/default/centos7-python36
-    		Tags: 1.0
+    singularity search centos
+    Found 72 container images for amd64 matching "centos":
 
-Notice there are different tags for the same container.
+	library://dcsouthwick/iotools/centos7:latest
 
+	library://dcsouthwick/iotools/centos7:sha256.48e81523aaad3d74e7af8b154ac5e75f2726cc6cab37f718237d8f89d905ff89
+		Minimal centos7 image from yum bootstrap
+
+	library://dtrudg/linux/centos:7,centos7,latest
+
+	library://dtrudg/linux/centos:centos6,6
+
+	library://emmeff/centos/centos:8
+
+	library://essen1999/default/centos-tree:latest
+
+	library://gallig/default/centos_benchmark-signed:7.7.1908
+		Signed by: 6B44B0BC9CD273CC6A71DA8CED6FA43EF8771A02
+
+	library://gmk/default/centos7-devel:latest
+		Signed by: 7853F08767A4596B3C1AD95E48E1080AB16ED1BC
+
+
+Containers can have multiple tags, and these are shown separated by
+commas after the ``:`` in the
+URL. E.g. ``library://dtrudg/linux/centos:7,centos7,latest`` is a
+single container image with 3 tags, ``7``, ``centos7``, and
+``latest``. You can ``singularity pull`` the container image using any
+one of these tags.
+                
+                
+Note that the results show ``amd64`` containers only. By default
+``search`` returns only containers with an architecture matching your
+current system. To e.g. search for ``arm64`` containers from an
+``amd64`` machine you can use the ``--arch`` flag:
+
+.. code-block:: console
+
+    singularity search --arch arm64 alpine
+    Found 5 container images for arm64 matching "alpine":
+
+	library://dtrudg-sylabs-2/multiarch/alpine:latest
+
+	library://geoffroy.vallee/alpine/alpine:latest
+		Signed by: 9D56FA7CAFB4A37729751B8A21749D0D6447B268
+
+	library://library/default/alpine:3.11.5,latest,3,3.11
+
+	library://library/default/alpine:3.9,3.9.2
+
+	library://sylabs/tests/passphrase_encrypted_alpine:3.11.5
+
+        
+You can also limit results to only signed containers with the
+``--signed`` flag:
+
+.. code-block:: console
+
+    singularity search --signed alpine
+    Found 45 container images for amd64 matching "alpine":
+
+	library://deep/default/alpine:latest,1.0.1
+		Signed by: 8883491F4268F173C6E5DC49EDECE4F3F38D871E
+
+	library://godloved/secure/alpine:20200514.0.0
+		Signed base image built directly from mirrors suitable for secure building. Make sure to check that the fingerprint is B7761495F83E6BF7686CA5F0C1A7D02200787921
+		Signed by: B7761495F83E6BF7686CA5F0C1A7D02200787921
+
+	library://godlovedc/blah/alpine:sha256.63259fd0a2acb88bb652702c08c1460b071df51149ff85dc88db5034532a14a0
+		Signed by: 8883491F4268F173C6E5DC49EDECE4F3F38D871E
+
+	library://heffaywrit/base/alpine:latest
+		Signed by: D4038BDDE21017435DFE5ADA9F2D10A25D64C1EF
+
+	library://hellseva/class/alpine:latest
+		Signed by: 6D60F95E86A593603897164F8E09E44D12A7111C
+
+	library://hpc110/default/alpine-miniconda:cupy
+		Signed by: 9FF48D6202271D3C842C53BD0D237BE8BB5B5C76
+        ...
+            
 .. _remote_builder:
 
 --------------

--- a/endpoint.rst
+++ b/endpoint.rst
@@ -110,16 +110,26 @@ To ``list`` existing remote endpoints, run this:
 
     $ singularity remote list
 
-    NAME           URI              GLOBAL
-    [SylabsCloud]  cloud.sylabs.io  YES
+    Cloud Services Endpoints
+    ========================
 
-The ``[...]`` brackets around the name ``SylabsCloud`` show that this
-is the current default remote endpoint.
+    NAME         URI              ACTIVE  GLOBAL  EXCLUSIVE
+    SylabsCloud  cloud.sylabs.io  YES     YES     NO
+
+    Keyservers
+    ==========
+
+    URI                     GLOBAL  INSECURE  ORDER
+    https://keys.sylabs.io  YES     NO        1*
+
+
+The ``YES`` in the ``ACTIVE`` column for ``SylabsCloud`` shows that
+this is the current default remote endpoint.
    
 To ``login`` to a remote, for the first time or if your token expires
 or was revoked:
 
-.. code-block:: none
+.. code-block:: console
 
     # Login to the default remote endpoint
     $ singularity remote login
@@ -135,6 +145,23 @@ or was revoked:
     API Key: 
     INFO:    API Key Verified!
 
+    
+If you ``login`` to a remote that you already have a valid token for,
+you will be prompted, and the new token will be verified, before it
+replaces your existing credential. If you enter an incorrect token
+your existing token will not be replaced:
+
+.. code-block:: console
+   
+    $ singularity remote login
+    An access token is already set for this remote. Replace it? [N/y]y
+    Generate an access token at https://cloud.sylabs.io/auth/tokens, and paste it here.
+    Token entered will be hidden for security.
+    Access Token: 
+    FATAL:   while verifying token: error response from server: Invalid Credentials
+
+    # Previous token is still in place
+    
     
 Add & Remove Remotes
 ====================

--- a/endpoint.rst
+++ b/endpoint.rst
@@ -46,7 +46,7 @@ services. If you only want to use the public services you just need to
 obtain an authentication token, and then ``singularity remote login``:
 
   1) Go to: https://cloud.sylabs.io/
-  2) Click "Sign in to Sylabs" and follow the sign in steps.
+  2) Click "Sign In" and follow the sign in steps.
   3) Click on your login id (same and updated button as the Sign in one).
   4) Select "Access Tokens" from the drop down menu.
   5) Enter a name for your new access token, such as "test token"
@@ -57,20 +57,23 @@ obtain an authentication token, and then ``singularity remote login``:
 Once your token is stored, you can check that you are able to connect
 to the services with the ``status`` subcommand:
 
-.. code:: none
+.. code:: console
 
     $ singularity remote status
     INFO:    Checking status of default remote.
-    SERVICE           STATUS  VERSION
-    Builder Service   OK      v1.1.4-0-g3ef2555
-    Consent Service   OK      v1.0.2-0-g2a24b4a
-    Keystore Service  OK      v1.9.0-0-g112eb0e-dirty
-    Library Service   OK      v1.0.4-0-g24d3b74
-    Token Service     OK      v1.0.2-0-g2a24b4a
+    SERVICE    STATUS  VERSION             URI
+    Builder    OK      v1.1.14-0-gc7a68c1  https://build.sylabs.io
+    Consent    OK      v1.0.2-0-g2a24b4a   https://auth.sylabs.io/consent
+    Keyserver  OK      v1.13.0-0-g13c778b  https://keys.sylabs.io
+    Library    OK      v1.0.16-0-gb7eeae4  https://library.sylabs.io
+    Token      OK      v1.0.2-0-g2a24b4a   https://auth.sylabs.io/token
+    INFO:    Access Token Verified!
+
+    Valid authentication token set (logged in).
 
 If you see any errors you may need to check if your system requires
 proxy environment variables to be set, or if a firewall is blocking
-access to ``*.sylabs.io``. Talk to your system adminitrator.
+access to ``*.sylabs.io``. Talk to your system administrator.
 
 You can interact with the public Sylabs Cloud using various Singularity commands:
 

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -289,23 +289,31 @@ containers of interest on the `Container Library <https://cloud.sylabs.io/librar
 
 .. code-block:: none
 
-    $ singularity search alp
-    No users found for 'alp'
+    singularity search tensorflow
+    Found 22 container images for amd64 matching "tensorflow":
 
-    Found 1 collections for 'alp'
-    	library://jchavez/alpine
+	library://ajgreen/default/tensorflow2-gpu-py3-r-jupyter:latest
+		Current software: tensorflow2; py3.7; r; jupyterlab1.2.6
+		Signed by: 1B8565093D80FA393BC2BD73EA4711C01D881FCB
 
-    Found 5 containers for 'alp'
-    	library://jialipassion/official/alpine
-    		Tags: latest
-    	library://dtrudg/linux/alpine
-    		Tags: 3.2 3.3 3.4 3.5 3.6 3.7 3.8 edge latest
-    	library://sylabsed/linux/alpine
-    		Tags: 3.6 3.7 latest
-    	library://library/default/alpine
-    		Tags: 3.1 3.2 3.3 3.4 3.5 3.6 3.7 3.8 latest
-    	library://sylabsed/examples/alpine
-    		Tags: latest
+	library://bensonyang/collection/tensorflow-rdma_v4.sif:latest
+
+	library://dxtr/default/hpc-tensorflow:0.1
+
+	library://emmeff/tensorflow/tensorflow:latest
+
+	library://husi253/default/tensorflow:20.01-tf1-py3-mrcnn-2020.10.07
+
+	library://husi253/default/tensorflow:20.01-tf1-py3-mrcnn-20201014
+
+	library://husi253/default/tensorflow:20.01-tf2-py3-lhx-20201007
+
+	library://irinaespejo/default/tensorflow-gan:sha256.0c1b6026ba2d6989242f418835d76cd02fc4cfc8115682986395a71ef015af18
+
+	library://jon/default/tensorflow:1.12-gpu
+		Signed by: D0E30822F7F4B229B1454388597B8AFA69C8EE9F
+
+        ...
 
 You can use the `pull <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_pull.html>`_
 and `build <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_build.html>`_
@@ -318,7 +326,7 @@ simply downloads the image file to your system.
 
 .. code-block:: none
 
-    $ singularity pull library://sylabsed/linux/alpine
+    $ singularity pull library://lolcow
 
 You can also use ``pull`` with the ``docker://`` uri to reference Docker images
 served from a registry. In this case ``pull`` does not just download an image

--- a/signNverify.rst
+++ b/signNverify.rst
@@ -33,7 +33,7 @@ container library, you must first generate an access token to the Sylabs Cloud.
 If you don't already have a valid access token, follow these steps:
 
   1) Go to: https://cloud.sylabs.io/
-  2) Click "Sign in to Sylabs" and follow the sign in steps.
+  2) Click "Sign In" and follow the sign in steps.
   3) Click on your login id (same and updated button as the Sign in one).
   4) Select "Access Tokens" from the drop down menu.
   5) Enter a name for your new access token, such as "test token"


### PR DESCRIPTION
Update remote status example
    
 - Closes #363

Update existing remote login (and list)
Does not redo the remote content for the new OCI login/logout or custom keyserver etc.
    
 - Closes #367
    
Update `singularity search` examples
    
 - Fixes #368

