### PR TITLE
Add warning for environment section regarding shell interpreter command execution timeout

### DIFF
--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -149,7 +149,7 @@ is launched. The ``%runscript`` is set to echo the value.
    environments, therefore all commands executed from the ``%environment`` section have
    an execution timeout of **5 seconds** for Singularity 3.6 and a **1 minute** timeout since
    Singularity 3.7. While it is fine to source a script from there, it is not recommended
-   to use this section to do potentially long initialization stuff because it would
+   to use this section to run potentially long initialization tasks because this would
    impact users running the image and the execution could abort due to timeout.
 
 -------------------------

--- a/environment_and_metadata.rst
+++ b/environment_and_metadata.rst
@@ -52,7 +52,6 @@ Summary of changes
    environment variable set by the container image.
 
 
-
 --------------------
 Environment Overview
 --------------------
@@ -144,6 +143,14 @@ is launched. The ``%runscript`` is set to echo the value.
 
    $ singularity run env.sif 
    Hello
+
+.. warning::
+   Singularity 3.6 uses an embedded shell interpreter to evaluate and setup container
+   environments, therefore all commands executed from the ``%environment`` section have
+   an execution timeout of **5 seconds** for Singularity 3.6 and a **1 minute** timeout since
+   Singularity 3.7. While it is fine to source a script from there, it is not recommended
+   to use this section to do potentially long initialization stuff because it would
+   impact users running the image and the execution could abort due to timeout.
 
 -------------------------
 Environment from the host


### PR DESCRIPTION
## This fixes or addresses the following GitHub issues:

- Fixes #350 
