### PR TITLE
Github hosted docs

### DIFF
--- a/.github/workflows/generate-web.yaml
+++ b/.github/workflows/generate-web.yaml
@@ -1,0 +1,75 @@
+name: Singularity User Docs Hosting
+
+on:
+  push:
+    branches:
+      - master
+
+jobs:
+  Build:
+    name: Build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Extract branch name
+        id: extract
+        shell: bash
+        run: echo ::set-output name=branch::${GITHUB_REF#refs/*/}
+
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: '3.x'
+
+      - name: Checkout Docs
+        uses: actions/checkout@v2
+        with:
+            fetch-depth: 0
+            path: build
+
+      - name: Install Deps
+        run: |
+            sudo apt-get update -y && \
+            sudo apt-get install -f -y build-essential libssl-dev uuid-dev squashfs-tools libseccomp-dev cryptsetup-bin libgpgme-dev \
+            texlive-latex-extra latexmk
+
+      - name: Install Sphinx
+        run: pip install sphinx sphinx-rtd-theme restructuredtext_lint pygments
+
+      - name: Singularity Submodule Init
+        working-directory: build
+        run: git submodule update --init --recursive
+
+      - name: Build HTML
+        working-directory: build
+        run: make html
+
+      - name: Checkout Docs
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+          ref: gh-pages
+          path: push
+
+      - name: Prep repo
+        working-directory: push
+        run: rm -rf docs/${{ steps.extract.outputs.branch }} && mkdir docs/${{ steps.extract.outputs.branch }}
+
+      - name: Copy Generated Docs
+        run: cp -r ./build/_build/html/* ./push/docs/${{ steps.extract.outputs.branch }}
+
+      - name: Add Jekyll Ignore
+        working-directory: push
+        run: touch docs/${{ steps.extract.outputs.branch }}/.nojekyll
+
+      - name: Setup Git Info
+        run: |
+            git config --global user.email "ci@hpcng.org"
+            git config --global user.name "singularity-user-docs-ci"
+
+      - name: Commit Docs
+        working-directory: push
+        run: git add . && git commit -m "auto-generated commit" --allow-empty
+
+      - name: Push Docs
+        working-directory: push
+        run: git push origin gh-pages

--- a/endpoint.rst
+++ b/endpoint.rst
@@ -62,16 +62,16 @@ access to ``*.sylabs.io``. Talk to your system administrator.
 
 You can interact with the public Sylabs Cloud using various Singularity commands:
 
-`pull <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_pull.html>`_,
-`push <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_push.html>`_,
-`build --remote <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_build.html#options>`_,
-`key <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_key.html>`_,
-`search <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_search.html>`_,
-`verify <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_verify.html>`_,
-`exec <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_exec.html>`_,
-`shell <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_shell.html>`_,
-`run <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_run.html>`_,
-`instance <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_instance.html>`_
+`pull <\{docbaseurl\}/\{version\}/cli/singularity_pull.html>`_,
+`push <\{docbaseurl\}/\{version\}/cli/singularity_push.html>`_,
+`build --remote <\{docbaseurl\}/\{version\}/cli/singularity_build.html#options>`_,
+`key <\{docbaseurl\}/\{version\}/cli/singularity_key.html>`_,
+`search <\{docbaseurl\}/\{version\}/cli/singularity_search.html>`_,
+`verify <\{docbaseurl\}/\{version\}/cli/singularity_verify.html>`_,
+`exec <\{docbaseurl\}/\{version\}/cli/singularity_exec.html>`_,
+`shell <\{docbaseurl\}/\{version\}/cli/singularity_shell.html>`_,
+`run <\{docbaseurl\}/\{version\}/cli/singularity_run.html>`_,
+`instance <\{docbaseurl\}/\{version\}/cli/singularity_instance.html>`_
 
 .. note::
 
@@ -523,13 +523,13 @@ Singularity will supply the correct credentials for the registry based off of
 the hostname when using the following commands with a ``docker://`` or 
 ``oras://`` URI:
 
-`pull <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_pull.html>`_,
-`push <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_push.html>`_,
-`build <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_build.html>`_,
-`exec <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_exec.html>`_,
-`shell <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_shell.html>`_,
-`run <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_run.html>`_,
-`instance <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_instance.html>`_
+`pull <\{docbaseurl\}/\{version\}/cli/singularity_pull.html>`_,
+`push <\{docbaseurl\}/\{version\}/cli/singularity_push.html>`_,
+`build <\{docbaseurl\}/\{version\}/cli/singularity_build.html>`_,
+`exec <\{docbaseurl\}/\{version\}/cli/singularity_exec.html>`_,
+`shell <\{docbaseurl\}/\{version\}/cli/singularity_shell.html>`_,
+`run <\{docbaseurl\}/\{version\}/cli/singularity_run.html>`_,
+`instance <\{docbaseurl\}/\{version\}/cli/singularity_instance.html>`_
 
 
 .. note::

--- a/index.rst
+++ b/index.rst
@@ -11,7 +11,7 @@ and running containers.
 
 For a detailed guide to installation and configuration, please see the
 separate Admin Guide for this version of Singularity at
-`<https://sylabs.io/guides/\{adminversion\}/admin-guide/>`__.
+`<\{admindocbaseurl\}/\{adminversion\}/>`__.
 
               
 Getting Started & Background Information

--- a/key_commands.rst
+++ b/key_commands.rst
@@ -15,7 +15,7 @@ Changes in Singularity 3.7
 --------------------------
 
 Singularity 3.7 introduces a global keyring which can be managed by administrators with the new ``--global`` option.
-This global keyring is used by ECL (https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html#ecl-toml)
+This global keyring is used by ECL (\{admindocbaseurl\}/\{adminversion\}/configfiles.html#ecl-toml)
 and allows administrators to manage public keys used during ECL image verification.
 
 ------------------

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -11,7 +11,7 @@ have root (administrative) privileges, and will install Singularity
 from source code. Other installation options, including building an
 RPM package and installing Singularity without root privileges are
 discussed in the `installation section of the admin guide
-<https://sylabs.io/guides/\{adminversion\}/admin-guide/installation.html>`__.
+<\{admindocbaseurl\}/\{adminversion\}/installation.html>`__.
 
 If you need to request an installation on your shared resource, see the
 :ref:`requesting an installation section <installation-request>` for
@@ -31,7 +31,7 @@ You will need a Linux system to run Singularity natively. Options for
 using Singularity on Mac and Windows machines, along with alternate
 Linux installation options are discussed in the `installation section of the
 admin guide
-<https://sylabs.io/guides/\{adminversion\}/admin-guide/installation.html>`__.
+<\{admindocbaseurl\}/\{adminversion\}/installation.html>`__.
 
 Install system dependencies
 ===========================
@@ -315,8 +315,8 @@ containers of interest on the `Container Library <https://cloud.sylabs.io/librar
 
         ...
 
-You can use the `pull <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_pull.html>`_
-and `build <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_build.html>`_
+You can use the `pull <\{docbaseurl\}/\{version\}/cli/singularity_pull.html>`_
+and `build <\{docbaseurl\}/\{version\}/cli/singularity_build.html>`_
 commands to download pre-built images from an external resource like the
 `Container Library <https://cloud.sylabs.io/library>`_ or
 `Docker Hub <https://hub.docker.com/>`_.
@@ -381,7 +381,7 @@ from the Container Library:
 Shell
 =====
 
-The `shell <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_shell.html>`_
+The `shell <\{docbaseurl\}/\{version\}/cli/singularity_shell.html>`_
 command allows you to spawn a new shell within your container and interact with
 it as though it were a small virtual machine.
 
@@ -417,7 +417,7 @@ exited.
 Executing Commands
 ==================
 
-The `exec <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_exec.html>`_
+The `exec <\{docbaseurl\}/\{version\}/cli/singularity_exec.html>`_
 command allows you to execute a custom command within a container by specifying
 the image file. For instance, to execute the ``cowsay`` program within the
 ``lolcow_latest.sif`` container:
@@ -457,7 +457,7 @@ Running a container
 
 Singularity containers contain :ref:`runscripts <runscript>`. These are user
 defined scripts that define the actions a container should perform when someone
-runs it. The runscript can be triggered with the `run <https://www.sylabs.io/guides/\{version\}/user-guide/cli/singularity_run.html>`_
+runs it. The runscript can be triggered with the `run <\{docbaseurl\}/\{version\}/cli/singularity_run.html>`_
 command, or simply by calling the container as though it were an executable.
 
 .. code-block:: none
@@ -720,10 +720,10 @@ to this:
     learn more about Singularity, I thought these items might be of interest:
 
         - Security: A discussion of security concerns is discussed at
-        https://www.sylabs.io/guides/{adminversion}/admin-guide/admin_quickstart.html
+        \{admindocbaseurl\}/\{adminversion\}/admin_quickstart.html
 
         - Installation:
-        https://www.sylabs.io/guides/{adminversion}/admin-guide/installation.html
+        \{admindocbaseurl\}/\{adminversion\}/installation.html
 
     If you have questions about any of the above, you can email the open source
     list (singularity@lbl.gov), join the open source slack channel

--- a/replacements.py
+++ b/replacements.py
@@ -11,7 +11,9 @@ def variableReplace(app, docname, source):
 variable_replacements = {
     "{InstallationVersion}" : "3.7.0",
     "\{version\}" : "3.7",
-    "\{adminversion\}" : "3.7"
+    "\{adminversion\}" : "3.7",
+    "\{docbaseurl\}" : "https://hpcng.github.io/singularity-userdocs",
+    "\{admindocbaseurl\}" : "https://hpcng.github.io/singularity-admindocs"
 }
 
 def setup(app):

--- a/replacements.py
+++ b/replacements.py
@@ -10,8 +10,8 @@ def variableReplace(app, docname, source):
 #Add the needed variables to be replaced either on code or on text on the next dictionary structure.
 variable_replacements = {
     "{InstallationVersion}" : "3.7.0",
-    "\{version\}" : "3.7",
-    "\{adminversion\}" : "3.7",
+    "\{version\}" : "master",
+    "\{adminversion\}" : "master",
     "\{docbaseurl\}" : "https://hpcng.github.io/singularity-userdocs",
     "\{admindocbaseurl\}" : "https://hpcng.github.io/singularity-admindocs"
 }

--- a/security.rst
+++ b/security.rst
@@ -135,12 +135,12 @@ files, to set security restrictions, grant or revoke a user’s
 capabilities, manage resources and authorize containers etc.
 
 For example, the `ecl.toml
-<https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html#ecl-toml>`_
+<\{admindocbaseurl\}/\{adminversion\}/configfiles.html#ecl-toml>`_
 file allows blacklisting and whitelisting of containers.
 
 Configuration files and their parameters are documented for administrators
 documented `here
-<https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html>`__.
+<\{admindocbaseurl\}/\{adminversion\}/configfiles.html>`__.
 
 cgroups support
 ****************
@@ -156,7 +156,7 @@ installed by default with Singularity as a guide. At runtime, the
 ``--apply-cgroups`` option is used to specify the location of the
 configuration file to apply to the container and cgroups are
 configured accordingly. More about cgroups support `here
-<https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html#cgroups-toml>`__.
+<\{admindocbaseurl\}/\{adminversion\}/configfiles.html#cgroups-toml>`__.
 
 ``--security`` options
 ***********************

--- a/security_options.rst
+++ b/security_options.rst
@@ -34,7 +34,7 @@ decided to grant a user (named ``pinger``) capabilities to open raw sockets so
 that they can use ``ping`` in a container where the binary is controlled via
 capabilities. For information about how to manage capabilities as an admin
 please refer to the
-`capability admin docs <https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html#capability.json>`_.
+`capability admin docs <\{admindocbaseurl\}/\{adminversion\}/configfiles.html#capability.json>`_.
 
 
 To take advantage of this granted capability as a user, ``pinger`` must also
@@ -68,8 +68,8 @@ in cloud-native architectures is dropping capabilities when spawning containers
 as the root user to help minimize attack surfaces. With a default installation
 of Singularity, containers created by the root user will maintain all
 capabilities. This behavior is configurable if desired. Check out the
-`capability configuration <https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html#capability.json>`_
-and `root default capabilities <https://sylabs.io/guides/\{adminversion\}/admin-guide/configfiles.html#setuid-and-capabilities>`_
+`capability configuration <\{admindocbaseurl\}/\{adminversion\}/configfiles.html#capability.json>`_
+and `root default capabilities <\{admindocbaseurl\}/\{adminversion\}/configfiles.html#setuid-and-capabilities>`_
 sections of the admin docs for more information.
 
 Assuming the root user will execute containers with the ``CAP_NET_RAW``


### PR DESCRIPTION
## Description of the Pull Request (PR):

This pr creates a github workflow that will generate documentation for this repository using github pages and does several things:
1. Introduces a tempate for the base url, including hostname, that the documentation is hosted at to allow self referencing and admin doc referencing urls to function properly.
2. Removes `/user-guide` and `/admin-guide` components of documentation paths. I am happy to undo this if it will cause significant issues to existing documentation hosts.
3. Adds a CI workflow on pushes to `master` that trigger documentation within the `gh-pages` branch of this repository to have updated documentation under `docs/master`.


## Extra preparation needed to make this live for this repository:
1. Enable github pages for the repo and specify the branch as `gh-pages` and the directory as `docs`.
2. Add `.nojekyll` files to the `gh-pages` branch root and `docs` directory`
3. (Optional) Add `index.html` redirect to "lastest" doc directory

## Example:
An example is live at my personal fork: https://ikaneshiro.github.io/singularity-userdocs
Relevant branches are `master` and `gh-pages`
