### PR TITLE
Fix singularity docs refs

### DIFF
--- a/contributing.rst
+++ b/contributing.rst
@@ -41,10 +41,10 @@ Raise an Issue
 
 For general bugs/issues, you can open an issue `at the GitHub repo 
 <https://github.com/hpcng/singularity/issues/new>`_. However, if you find a 
-security  related issue/problem, please email Sylabs directly at 
-`security@sylabs.io <mailto:security@sylabs.io>`_. More information about the 
-Sylabs security policies and procedures can be found `here 
-<https://www.sylabs.io/singularity/security-policy/>`__
+security  related issue/problem, please email Singularity Project Team directly at 
+`singularity-security@hpcng.org <mailto:singularity-security@hpcng.org>`_. More information about the 
+Singularity security policies and procedures can be found `here 
+<https://singularity.hpcng.org/security-policy/>`__
 
 -------------------
 Write Documentation
@@ -181,7 +181,7 @@ Step 5. Submit a Pull Request
 Once you have pushed your branch, then you can go to your fork (in the web GUI 
 on GitHub) and `submit a Pull Request
 <https://help.github.com/articles/creating-a-pull-request/>`_. Regardless of the 
-name of your branch, your PR should be submitted to the Sylabs ``master`` 
+name of your branch, your PR should be submitted to the Singularity ``master`` 
 branch. Submitting your PR will open a conversation thread for the maintainers 
 of Singularity to discuss your contribution. At this time, the continuous 
 integration that is linked with the code base will also be executed. If there is 

--- a/contributing.rst
+++ b/contributing.rst
@@ -41,7 +41,7 @@ Raise an Issue
 
 For general bugs/issues, you can open an issue `at the GitHub repo 
 <https://github.com/hpcng/singularity/issues/new>`_. However, if you find a 
-security  related issue/problem, please email Singularity Project Team directly at 
+security  related issue/problem, please email the Singularity Security Team directly at 
 `singularity-security@hpcng.org <mailto:singularity-security@hpcng.org>`_. More information about the 
 Singularity security policies and procedures can be found `here 
 <https://singularity.hpcng.org/security-policy/>`__
@@ -204,7 +204,6 @@ will need to follow the next steps:
         git push origin master && # to update your fork \
         git checkout new-feature && \
         git merge master 
-
 
 
 

--- a/definition_files.rst
+++ b/definition_files.rst
@@ -35,8 +35,8 @@ A Singularity Definition file is divided into two parts:
    sections that produce scripts to be executed at runtime can accept options
    intended for ``/bin/sh``
 
-For more in-depth and practical examples of def files, see the `Sylabs examples
-repository <https://github.com/sylabs/examples>`_
+For more in-depth and practical examples of def files, see the `Singularity examples
+repository <https://github.com/hpcng/singularity/tree/master/examples>`_
 
 For a comparison between Dockerfile and Singularity definition file,
 please see: :ref:`this section <sec:deffile-vs-dockerfile>`.

--- a/oci_runtime.rst
+++ b/oci_runtime.rst
@@ -740,7 +740,7 @@ Beyond ``root.path``, the ``config.json`` file includes a multitude of additiona
 
 For a comprehensive discussion of all the ``config.json`` file properties, refer to the `implementation guide <https://github.com/opencontainers/runtime-spec/blob/master/config.md>`_. 
 
-Technically, the ``overlay`` directory was *not* content expected of an OCI compliant filesystem bundle. As detailed in the section dedicated to `Persistent Overlays <https://www.sylabs.io/guides/3.0/user-guide/persistent_overlays.html>`_, these directories allow for the introduction of 
+Technically, the ``overlay`` directory was *not* content expected of an OCI compliant filesystem bundle. As detailed in the section dedicated to `Persistent Overlays <https://singularity.hpcng.org/user-docs/master/persistent_overlays.html>`_, these directories allow for the introduction of 
 a writable file system on an otherwise immutable read-only container; thus they permit the illusion of read-write access.
 
 .. TODO Need to ensure that what's written above is correct 

--- a/quick_start.rst
+++ b/quick_start.rst
@@ -17,8 +17,8 @@ If you need to request an installation on your shared resource, see the
 :ref:`requesting an installation section <installation-request>` for
 information to send to your system administrator.
 
-For any additional help or support contact the Sylabs team:
-https://www.sylabs.io/contact/
+For any additional help or support contact the Singularity Community:
+https://singularity.hpcng.org/help
 
 
 .. _quick-installation:

--- a/security.rst
+++ b/security.rst
@@ -27,13 +27,13 @@ addition to ensuring that containers are run without elevated
 privileges where appropriate, and that containers are produced by
 trusted sources, users must monitor their containers for newly
 discovered vulnerabilities and update when necessary just as they
-would with any other software. Sylabs is constantly probing to find
+would with any other software. Singularity Community is constantly probing to find
 and patch vulnerabilities within Singularity, and will continue to do
 so.
 
 If you suspect you have found a vulnerability in Singularity, please
 follow the steps in our published `Security Policy
-<https://sylabs.io/security-policy>`__.
+<https://singularity.hpcng.org/security-policy/>`__.
 
 so that it can be disclosed, investigated, and fixed in an appropriate
 manner.
@@ -51,8 +51,8 @@ beyond that offered by the open source project. Security and bug-fix
 patches are backported to select versions of Singularity PRO, so that
 they can be deployed long-term where required. PRO users receive
 security fixes (without specific notification or detail) prior to
-public disclosure, as detailed in the `Sylabs Security Policy
-<https://sylabs.io/security-policy>`__.
+public disclosure, as detailed in the `Singularity Community Security Policy
+<https://singularity.hpcng.org/security-policy/>`__.
 
 
 Singularity Runtime & User Privilege

--- a/security.rst
+++ b/security.rst
@@ -27,7 +27,7 @@ addition to ensuring that containers are run without elevated
 privileges where appropriate, and that containers are produced by
 trusted sources, users must monitor their containers for newly
 discovered vulnerabilities and update when necessary just as they
-would with any other software. Singularity Community is constantly probing to find
+would with any other software. The Singularity community is constantly probing to find
 and patch vulnerabilities within Singularity, and will continue to do
 so.
 
@@ -244,7 +244,6 @@ Authentication and encryption
    request between the services is authenticated using the
    authentication token supplied by the user in the associated
    request.
-
 
 
 

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -868,7 +868,7 @@ A copy of the SIF file created by the service remains in the Sylabs Cloud Singul
 .. _sec:mandatory_headers_docker_locally_bootstrapped_def_file:
 
 Mandatory Header Keywords: Locally Bootstrapped
-----------------------------------------------
+------------------------------------------------
 
 When ``docker-daemon`` is the bootstrap agent in a Singularity definition file, SIF containers can be created from images cached locally by Docker. Suppose the definition file ``lolcow-d.def`` has contents:
 
@@ -1466,7 +1466,7 @@ Building Containers for Singularity from OCI Images
 .. _cli-oci-bootstrap-agent:
 
 Working Locally from the Singularity Command Line: ``oci`` Bootstrap Agent
--------------------------------------------------------------------------
+--------------------------------------------------------------------------
 
 The example detailed in the previous section can be used to illustrate how a SIF file for use by Singularity can be created from the local cache - an albeit contrived example, that works because the Singularity cache is compliant with the OCI Image Layout Specification.
 
@@ -1522,7 +1522,7 @@ does not *uniquely* specify an image from which to bootstrap the ``build`` proce
 .. _cli-oci-archive-bootstrap-agent:
 
 Working Locally from the Singularity Command Line: ``oci-archive`` Bootstrap Agent
----------------------------------------------------------------------------------
+----------------------------------------------------------------------------------
 
 OCI archives, i.e., ``tar`` files obeying the OCI Image Layout Specification :ref:`as discussed previously <misc:OCI_Image_Layout_Specification>`, can seed creation of a container for Singularity. In this case, use is made of the ``oci-archive`` bootstrap agent.
 

--- a/singularity_and_docker.rst
+++ b/singularity_and_docker.rst
@@ -752,7 +752,7 @@ Working with Definition Files
 .. _sec:def_file_mandatory_headers_remotely_bootstrapped:
 
 Mandatory Header Keywords: Remotely Bootstrapped
------------------------------------------------
+-------------------------------------------------
 
 Akin to a set of blueprints that explain how to build a custom container, Singularity definition files (or "def files") are considered in detail :ref:`elsewhere in this manual <definition-files>`. Therefore, only def file nuances specific to interoperability with Docker receive consideration here.
 


### PR DESCRIPTION
## Description of the Pull Request (PR):
Updates references to user-docs links that before pointed to Sylabs links.

## This fixes or addresses the following GitHub issues:
No issues refs to here.

**Before submitting a PR, make sure you have done the following:**

* Read the [Guidelines for Contributing](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md), and this PR conforms to the stated requirements.
* Added changes to the CHANGELOG if necessary according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
* Added tests to validate this PR and tested this PR locally with a `make testall`
* Based this PR against the appropriate branch according to the [Contribution Guidelines](https://github.com/hpcng/singularity/blob/master/CONTRIBUTING.md)
* Added myself as a contributor to the [Contributors File](https://github.com/hpcng/singularity/blob/master/CONTRIBUTORS.md)

Attn: @singularity-maintainers
