### PR TITLE
Update quick_start.rst

### DIFF
--- a/quick_start.rst
+++ b/quick_start.rst
@@ -119,7 +119,7 @@ proceed with the installation.
     $ export VERSION={InstallationVersion} && # adjust this as necessary \
         wget https://github.com/hpcng/singularity/releases/download/v${VERSION}/singularity-${VERSION}.tar.gz && \
         tar -xzf singularity-${VERSION}.tar.gz && \
-        cd singularity
+        cd singularity-${VERSION}
 
 .. _compile:
 


### PR DESCRIPTION


## Description of the Pull Request (PR):

Update docs to account for $VERSION ENV variable when un-tarring the singularity tarball
fixes this issue when installing: 

```
2021-07-29 15:59:00 (15.5 MB/s) - ‘singularity-3.8.0.tar.gz’ saved [7892955/7892955]

-bash: cd: singularity: No such file or directory
```
