### PR TITLE
Fix a 404 link error in bind_paths_and_mounts.rst

### DIFF
--- a/bind_paths_and_mounts.rst
+++ b/bind_paths_and_mounts.rst
@@ -8,7 +8,7 @@ Bind Paths and Mounts
 
 .. _sec:bindpaths:
 
-If `not disabled by the system administrator <\{admindocs\}/config_files.html#bind-mount-management>`_,
+If `not disabled by the system administrator <\{admindocs\}/configfiles.html#bind-mount-management>`_,
 Singularity allows you to map directories on your host system to directories
 within your container using bind mounts. This allows you to read and write data
 on the host system with ease.


### PR DESCRIPTION
## Description of the Pull Request (PR):

Fix a link error in `bind_paths_and_mounts.rst`.


## This fixes or addresses the following GitHub issues:

- Fixes #
Change `config_files` to `configfiles`.